### PR TITLE
Add search functionality to ord_client

### DIFF
--- a/ord_interface/Dockerfile
+++ b/ord_interface/Dockerfile
@@ -15,7 +15,7 @@
 # To build the interface using the current state of ord-schema:
 # $ cd path/to/ord-schema
 # $ docker build \
-#     --file=ord_schema/interface/Dockerfile \
+#     --file=ord_interface/Dockerfile \
 #     -t openreactiondatabase/ord-interface \
 #     .
 #

--- a/ord_interface/build_database.py
+++ b/ord_interface/build_database.py
@@ -20,7 +20,6 @@ files and load them into PostgreSQL with the COPY command.
 import csv
 import glob
 import os
-import random
 import sys
 
 from absl import app
@@ -29,9 +28,10 @@ from absl import logging
 import psycopg2
 from psycopg2 import sql
 
-import ord_interface
 from ord_schema import message_helpers
 from ord_schema.proto import dataset_pb2
+
+import ord_interface
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string('input', None, 'Input pattern (glob).')

--- a/ord_interface/build_database_test.py
+++ b/ord_interface/build_database_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for ord_schema.interface.build_database."""
+"""Tests for ord_interface.build_database."""
 
 import os
 import tempfile

--- a/ord_interface/docker-compose.yml
+++ b/ord_interface/docker-compose.yml
@@ -16,6 +16,7 @@ version: "3"
 services:
   ord-postgres:
     image: "openreactiondatabase/ord-postgres:${ORD_POSTGRES_TAG:-latest}"
+    command: ["postgres", "-c", "log_statement=all"]
   web:
     depends_on:
       - ord-postgres

--- a/ord_interface/docker/Dockerfile
+++ b/ord_interface/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 # To build an updated ord-postgres image containing the latest data:
 # $ cd path/to/ord-schema
-# $ ./ord_schema/interface/docker/update_image.sh
+# $ ./docker/update_image.sh
 #
 # To push the built image to Docker Hub:
 # docker push openreactiondatabase/ord-postgres
@@ -63,8 +63,10 @@ RUN git clone "https://github.com/Open-Reaction-Database/${ORD_REPO}.git"
 
 # Copy local state.
 WORKDIR "${ORD_ROOT}/ord-interface"
+COPY setup.py .
 COPY ord_interface/ ord_interface/
 COPY ord_interface/docker/postgres.conf /etc/postgresql/postgresql.conf
+RUN python setup.py install
 
 # NOTE(kearnes): Use non-standard PGDATA so the database persists; see
 # https://nickjanetakis.com/blog/docker-tip-79-saving-a-postgres-database-in-a-docker-image.

--- a/ord_interface/ord_client.py
+++ b/ord_interface/ord_client.py
@@ -17,9 +17,9 @@ import urllib.parse
 
 import requests
 
+from ord_interface import query
 from ord_schema import message_helpers
 from ord_schema import validations
-from ord_schema.interface import query
 from ord_schema.proto import dataset_pb2
 
 TARGET = 'https://client.open-reaction-database.org'
@@ -150,7 +150,14 @@ class OrdClient:
 
         Returns:
             A Dataset containing the matched reactions.
+
+        Raises:
+            ValueError: A reaction ID is invalid.
         """
+        if reaction_ids:
+            for reaction_id in reaction_ids:
+                if not validations.is_valid_reaction_id(reaction_id):
+                    raise ValueError(f'Invalid reaction ID: {reaction_id}')
         if components is not None:
             component_params = [
                 component.get_params() for component in components

--- a/ord_interface/ord_client.py
+++ b/ord_interface/ord_client.py
@@ -17,10 +17,11 @@ import urllib.parse
 
 import requests
 
-from ord_interface import query
 from ord_schema import message_helpers
 from ord_schema import validations
 from ord_schema.proto import dataset_pb2
+
+from ord_interface import query
 
 TARGET = 'https://client.open-reaction-database.org'
 ORD_DATA_URL = 'https://github.com/Open-Reaction-Database/ord-data/raw/main/'

--- a/ord_interface/ord_client_test.py
+++ b/ord_interface/ord_client_test.py
@@ -11,28 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for ord_schema.interface.ord_client."""
+"""Tests for ord_interface.ord_client."""
 
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from ord_schema.interface import ord_client
+from ord_interface import ord_client
 
 
 class OrdClientTest(parameterized.TestCase, absltest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client = ord_client.OrdClient()
+        self.client = ord_client.OrdClient(target='http://localhost:5000')
 
-    @absltest.skip('Temporarily disabled for Reaction schema migration.')
     @parameterized.parameters(
         ('ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c', 264))
     def test_fetch_dataset(self, dataset_id, expected_num_reactions):
         dataset = self.client.fetch_dataset(dataset_id)
         self.assertLen(dataset.reactions, expected_num_reactions)
 
-    @absltest.skip('Temporarily disabled for Reaction schema migration.')
     @parameterized.parameters(
         (['ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c'], [264]))
     def test_fetch_datasets(self, dataset_ids, expected_num_reactions):
@@ -42,7 +40,6 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
         for dataset, expected in zip(datasets, expected_num_reactions):
             self.assertLen(dataset.reactions, expected)
 
-    @absltest.skip('Temporarily disabled for Reaction schema migration.')
     @parameterized.parameters(
         ('ord-f0621fa47ac74fd59f9da027f6d13fc4', 'Jun Li'),
         ('ord-c6fbf2aab30841d198a27068a65a9a98', 'Steven Kearnes'))
@@ -51,7 +48,6 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
         self.assertEqual(reaction.provenance.record_created.person.name,
                          created_by)
 
-    @absltest.skip('Temporarily disabled for Reaction schema migration.')
     @parameterized.parameters(([
         'ord-f0621fa47ac74fd59f9da027f6d13fc4',
         'ord-c6fbf2aab30841d198a27068a65a9a98'
@@ -74,24 +70,24 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
     def test_query_reaction_smarts(self):
         dataset = self.client.query(
             reaction_smarts='FC(F)(F)c1ccc([F,Cl,Br,I])cc1>CS(=O)C>')
-        self.assertLen(dataset.reactions, 862)
+        self.assertLen(dataset.reactions, 21)
 
     def test_query_single_component(self):
         component = ord_client.ComponentQuery('FC(F)(F)c1ccc(Br)cc1',
                                               source='input',
                                               mode='exact')
         dataset = self.client.query(components=[component])
-        self.assertLen(dataset.reactions, 287)
+        self.assertLen(dataset.reactions, 7)
 
     def test_query_multiple_components(self):
         component1 = ord_client.ComponentQuery('FC(F)(F)c1ccc(Br)cc1',
                                                source='input',
                                                mode='exact')
-        component2 = ord_client.ComponentQuery('Cc1cc(C)on1',
+        component2 = ord_client.ComponentQuery('CN(C)C(=NC(C)(C)C)N(C)C',
                                                source='input',
                                                mode='exact')
         dataset = self.client.query(components=[component1, component2])
-        self.assertLen(dataset.reactions, 12)
+        self.assertLen(dataset.reactions, 2)
 
     def test_query_stereochemistry(self):
         # TODO(kearnes): Add a test once we have more chiral stuff.
@@ -102,7 +98,7 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
                                               source='input',
                                               mode='similar')
         dataset = self.client.query(components=[component], similarity=0.6)
-        self.assertLen(dataset.reactions, 575)
+        self.assertLen(dataset.reactions, 14)
 
 
 if __name__ == '__main__':

--- a/ord_interface/ord_client_test.py
+++ b/ord_interface/ord_client_test.py
@@ -16,25 +16,27 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from ord_interface import ord_client
+from ord_schema.interface import ord_client
 
 
 class OrdClientTest(parameterized.TestCase, absltest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.client = ord_client.OrdClient()
 
     @absltest.skip('Temporarily disabled for Reaction schema migration.')
     @parameterized.parameters(
         ('ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c', 264))
     def test_fetch_dataset(self, dataset_id, expected_num_reactions):
-        client = ord_client.OrdClient()
-        dataset = client.fetch_dataset(dataset_id)
+        dataset = self.client.fetch_dataset(dataset_id)
         self.assertLen(dataset.reactions, expected_num_reactions)
 
     @absltest.skip('Temporarily disabled for Reaction schema migration.')
     @parameterized.parameters(
         (['ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c'], [264]))
     def test_fetch_datasets(self, dataset_ids, expected_num_reactions):
-        client = ord_client.OrdClient()
-        datasets = client.fetch_datasets(dataset_ids)
+        datasets = self.client.fetch_datasets(dataset_ids)
         self.assertLen(dataset_ids, len(expected_num_reactions))
         self.assertLen(datasets, len(expected_num_reactions))
         for dataset, expected in zip(datasets, expected_num_reactions):
@@ -45,8 +47,7 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
         ('ord-f0621fa47ac74fd59f9da027f6d13fc4', 'Jun Li'),
         ('ord-c6fbf2aab30841d198a27068a65a9a98', 'Steven Kearnes'))
     def test_fetch_reaction(self, reaction_id, created_by):
-        client = ord_client.OrdClient()
-        reaction = client.fetch_reaction(reaction_id)
+        reaction = self.client.fetch_reaction(reaction_id)
         self.assertEqual(reaction.provenance.record_created.person.name,
                          created_by)
 
@@ -56,13 +57,52 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
         'ord-c6fbf2aab30841d198a27068a65a9a98'
     ], ['Jun Li', 'Steven Kearnes']))
     def test_fetch_reactions(self, reaction_ids, created_by):
-        client = ord_client.OrdClient()
-        reactions = client.fetch_reactions(reaction_ids)
+        reactions = self.client.fetch_reactions(reaction_ids)
         self.assertLen(reaction_ids, len(created_by))
         self.assertLen(reactions, len(created_by))
         for reaction, expected in zip(reactions, created_by):
             self.assertEqual(reaction.provenance.record_created.person.name,
                              expected)
+
+    def test_query_reaction_ids(self):
+        dataset = self.client.query(reaction_ids=[
+            'ord-f0621fa47ac74fd59f9da027f6d13fc4',
+            'ord-c6fbf2aab30841d198a27068a65a9a98'
+        ])
+        self.assertLen(dataset.reactions, 2)
+
+    def test_query_reaction_smarts(self):
+        dataset = self.client.query(
+            reaction_smarts='FC(F)(F)c1ccc([F,Cl,Br,I])cc1>CS(=O)C>')
+        self.assertLen(dataset.reactions, 862)
+
+    def test_query_single_component(self):
+        component = ord_client.ComponentQuery('FC(F)(F)c1ccc(Br)cc1',
+                                              source='input',
+                                              mode='exact')
+        dataset = self.client.query(components=[component])
+        self.assertLen(dataset.reactions, 287)
+
+    def test_query_multiple_components(self):
+        component1 = ord_client.ComponentQuery('FC(F)(F)c1ccc(Br)cc1',
+                                               source='input',
+                                               mode='exact')
+        component2 = ord_client.ComponentQuery('Cc1cc(C)on1',
+                                               source='input',
+                                               mode='exact')
+        dataset = self.client.query(components=[component1, component2])
+        self.assertLen(dataset.reactions, 12)
+
+    def test_query_stereochemistry(self):
+        # TODO(kearnes): Add a test once we have more chiral stuff.
+        pass
+
+    def test_query_similarity(self):
+        component = ord_client.ComponentQuery('FC(F)(F)c1ccc(Br)cc1',
+                                              source='input',
+                                              mode='similar')
+        dataset = self.client.query(components=[component], similarity=0.6)
+        self.assertLen(dataset.reactions, 575)
 
 
 if __name__ == '__main__':

--- a/ord_interface/query.py
+++ b/ord_interface/query.py
@@ -267,21 +267,22 @@ class ReactionComponentQuery(ReactionQueryBase):
         if not self._predicates:
             return {}
         self._setup(cursor)
-        components = [
-            sql.SQL("""
-            SELECT DISTINCT reaction_id, serialized
-            FROM reactions """)
-        ]
-        components.extend(self._get_tables())
-        components.append(sql.SQL("""
-            WHERE """))
-        args = []
         predicates = []
+        args = []
         for predicate in self._predicates:
+            components = [
+                sql.SQL("""
+                SELECT DISTINCT reaction_id, serialized
+                FROM reactions """)
+            ]
+            components.extend(self._get_tables())
+            components.append(sql.SQL("""
+                WHERE """))
             predicate_sql, predicate_args = predicate.get()
-            predicates.append(predicate_sql)
+            components.append(predicate_sql)
             args.extend(predicate_args)
-        components.append(sql.Composed(predicates).join(' AND '))
+            predicates.append(sql.Composed(components))
+        components = [sql.Composed(predicates).join(' INTERSECT ')]
         if limit:
             components.append(sql.SQL(' LIMIT %s'))
             args.append(limit)

--- a/ord_interface/query_test.py
+++ b/ord_interface/query_test.py
@@ -11,15 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for ord_schema.interface.query."""
+"""Tests for ord_interface.query."""
 
 from absl.testing import absltest
 from absl.testing import parameterized
 import numpy as np
 import psycopg2
 
-from ord_schema import interface
-
+import ord_interface
 from ord_interface import query
 
 
@@ -28,12 +27,12 @@ class QueryTest(parameterized.TestCase, absltest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.postgres = query.OrdPostgres(
-            dbname=interface.POSTGRES_DB,
-            user=interface.POSTGRES_USER,
-            password=interface.POSTGRES_PASSWORD,
+            dbname=ord_interface.POSTGRES_DB,
+            user=ord_interface.POSTGRES_USER,
+            password=ord_interface.POSTGRES_PASSWORD,
             # Matches the service name in docker-compose.yml.
             host='ord-postgres',
-            port=interface.POSTGRES_PORT)
+            port=ord_interface.POSTGRES_PORT)
 
     def test_reaction_id_query(self):
         reaction_ids = [

--- a/ord_interface/search.py
+++ b/ord_interface/search.py
@@ -39,8 +39,9 @@ import os
 
 import flask
 
-from ord_interface import query
 from ord_schema.visualization import generate_text
+
+from ord_interface import query
 
 app = flask.Flask(__name__, template_folder='.')
 app.config['ORD_POSTGRES_HOST'] = os.getenv('ORD_POSTGRES_HOST', 'localhost')

--- a/ord_interface/search.py
+++ b/ord_interface/search.py
@@ -39,7 +39,7 @@ import os
 
 import flask
 
-from ord_schema.interface import query
+from ord_interface import query
 from ord_schema.visualization import generate_text
 
 app = flask.Flask(__name__, template_folder='.')

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -34,6 +34,7 @@ status=0
 
 CONTAINER="$(docker ps -q --filter name=web)"
 docker exec "${CONTAINER}" python ord_interface/build_database_test.py || status=1
+docker exec "${CONTAINER}" python ord_interface/ord_client_test.py || status=1
 docker exec "${CONTAINER}" python ord_interface/query_test.py || status=1
 
 # Shut down the containers.


### PR DESCRIPTION
Transfer from https://github.com/Open-Reaction-Database/ord-schema/pull/504

- Replicates the search functionality from https://client.open-reaction-database.org in the Python client
- Fixes a bug in multi-component queries (use INTERSECT instead of AND)
- Enables logging of all SQL queries in the postgres container

Resolves #3 