### PR TITLE
Cache docker layers for tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,6 +16,12 @@ name: CI
 
 on: [pull_request, push]
 
+env:
+  # See https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei.
+  CACHE_TARGET_A: "docker.pkg.github.com/open-reaction-database/ord-interface/postgres-cache"
+  CACHE_TARGET_B: "docker.pkg.github.com/open-reaction-database/ord-interface/interface-cache"
+
+
 jobs:
   test_ord_interface:
     runs-on: ubuntu-latest
@@ -24,7 +30,20 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Build and test interface
+      - name: Setup docker cache
+        run: |
+          docker login docker.pkg.github.com -u "${GITHUB_ACTOR}" --password="${{ secrets.GITHUB_TOKEN }}"
+          docker pull "${CACHE_TARGET_A}"
+          docker pull "${CACHE_TARGET_B}"
+      - name: Run interface tests
         run: |
           cd "${GITHUB_WORKSPACE}"
-          ./run_tests.sh
+          ./run_tests.sh "--cache-from=${CACHE_TARGET_A}" "--cache-from=${CACHE_TARGET_B}"
+      - name: Update docker cache
+        run: |
+          docker tag ord-postgres:empty "${CACHE_TARGET_A}"
+          docker push "${CACHE_TARGET_A}"
+          docker tag openreactiondatabase/ord-interface "${CACHE_TARGET_B}"
+          docker push "${CACHE_TARGET_B}"
+        # NOTE(kearnes): Actions in forks cannot update the cache.
+        if: ${{ ! github.event.pull_request.head.repo.fork }}

--- a/ord_interface/docker/update_image.sh
+++ b/ord_interface/docker/update_image.sh
@@ -18,7 +18,7 @@ set -ex
 docker build \
   --file=ord_interface/docker/Dockerfile \
   -t ord-postgres:empty \
-  .
+  . "$@"
 CONTAINER="$(docker run --rm -d ord-postgres:empty)"
 echo "Waiting 5s for the server to start..."
 sleep 5

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -17,10 +17,10 @@ set -e
 
 # Build the ord-postgres image.
 export ORD_POSTGRES_TAG=test
-./ord_interface/docker/update_image.sh
+./ord_interface/docker/update_image.sh "$@"
 
 # Build the ord-interface image.
-docker build -f ord_interface/Dockerfile -t openreactiondatabase/ord-interface .
+docker build -f ord_interface/Dockerfile -t openreactiondatabase/ord-interface . "$@"
 
 # Launch the web server.
 cd ord_interface && docker-compose up --detach

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -20,7 +20,9 @@ export ORD_POSTGRES_TAG=test
 ./ord_interface/docker/update_image.sh "$@"
 
 # Build the ord-interface image.
+set -x
 docker build -f ord_interface/Dockerfile -t openreactiondatabase/ord-interface . "$@"
+set +x
 
 # Launch the web server.
 cd ord_interface && docker-compose up --detach


### PR DESCRIPTION
With 100% caching (no changes to any layers), the test time drops from 6:13 at HEAD to 3:20 in this PR.