### PR TITLE
Updates to ord-interface layout

### DIFF
--- a/ord_interface/search.html
+++ b/ord_interface/search.html
@@ -45,7 +45,7 @@
         grid-row: controls;
         grid-row-gap: 18px;
         grid-column-gap: 18px;
-        grid-template-columns: [text] 220px [source] auto [mode] auto;
+        grid-template-columns: [text] 220px [source] auto [mode] auto [remove] auto;
         align-items: center;
       }
       #reactions {
@@ -130,12 +130,13 @@
         <option value="input">input</option>
         <option value="output">output</option>
       </select>
-      <select class="component" style="grid-column: mode">
+      <select class="mode" style="grid-column: mode">
         <option value="exact">exact</option>
         <option value="similar">similar</option>
         <option value="substructure">substructure</option>
         <option value="smarts">smarts</option>
       </select>
+      <a href="#" class="remove">remove</a>
     </div>
 
     <script>
@@ -159,6 +160,14 @@
       // Add a component field, for "+ component" button (and initialization).
       function addComponent() {
         const component = $('#component_template').clone();
+        // Hook up the "remove" button.
+        $('.remove', component).click(function() {
+            $(this).prevAll('.component').first().remove();
+            $(this).prevAll('.source').first().remove();
+            $(this).prevAll('.mode').first().remove();
+            $(this).remove();
+        });
+        // Insert the component into the form.
         const anchor = $('#add_component');
         component.children().each((index, node) => {
           anchor.before(node);

--- a/ord_interface/search.html
+++ b/ord_interface/search.html
@@ -53,7 +53,7 @@
         grid-row: controls;
         grid-row-gap: 18px;
         grid-column-gap: 18px;
-        grid-template-columns: [labels] auto [text] 220px;
+        grid-template-columns: [labels] auto [text] 350px;
         align-items: center;
       }
       .label {
@@ -101,7 +101,7 @@
         <input type="checkbox" id="stereo">
 
         <span style="grid-column: text; text-align: right">similarity threshold</span>
-        <input id="similarity" type="text" style="width: 60px">
+        <input id="similarity" type="text" value="0.5" style="width: 60px">
       </div>
 
       <div id="reactions" style="display: none;">
@@ -173,12 +173,7 @@
           anchor.before(node);
         });
         // Return value is the text field <div/> of the new component.
-        return anchor.prev().prev().prev();
-      }
-
-      // Get the text from an .edittext div.
-      function getText(node) {
-        return node.text().trim();
+        return anchor.prevAll('.component').first();
       }
 
       // Get the component source (input/output).
@@ -198,12 +193,12 @@
 
       // Get the current value of the similarity threshold.
       function getSimilarity() {
-        return $('#similarity').text();
+        return $('#similarity').val();
       }
 
       // Set the value of the similarity threshold.
       function setSimilarity(similarity) {
-        $('#similarity').text(similarity);
+        $('#similarity').val(similarity);
       }
 
       // Read back the user inputs and build a query URL.
@@ -212,14 +207,14 @@
         let hasReagent = false;
 
         // Components.
-        const components = $('.component.edittext');
+        const components = $('.component');
         components.each((index, node) => {
           const component = $(node);
           if (component.is(':hidden')) {
             // The template.
             return;
           }
-          const componentText = getText(component);
+          const componentText = component.val().trim();
           if (componentText) {
             const sourceTable = getComponentSource(component);
             const matchMode = getMatchMode(component);
@@ -232,11 +227,11 @@
           const useStereochemistry = getUseStereochemistry();
           path += 'use_stereochemistry=' + encodeURIComponent(useStereochemistry) + '&';
           const similarity = getSimilarity();
-          path += 'similarity=' + encodeURIComponent(similarity / 100) + '&';
+          path += 'similarity=' + encodeURIComponent(similarity) + '&';
         }
         // Reaction IDs.
         const reactionsNode = $('#reaction_ids');
-        const reactionIdsText = reactionsNode.html();
+        const reactionIdsText = reactionsNode.val();
         const matches = reactionIdsText.matchAll(/(ord-[0-9a-f]+)/g);
         const reactionIds = [];
         for (const match of matches) {
@@ -247,7 +242,7 @@
         }
         // Reaction SMARTS.
         const reactionSmarts = $('#reaction_smarts');
-        const reactionSmartsText = getText(reactionSmarts);
+        const reactionSmartsText = reactionSmarts.val().trim();
         if (reactionSmartsText) {
           path += 'reaction_smarts=' + encodeURIComponent(reactionSmartsText) + '&';
         }
@@ -265,10 +260,10 @@
         // Components.
         if ('components' in query && (query.components.length > 0)) {
           query.components.forEach(component => {
-            const edittext = addComponent();
-            edittext.text(component.pattern);
-            edittext.next().val(component.source);
-            edittext.next().next().val(component.mode);
+            const node = addComponent();
+            node.val(component.pattern);
+            node.nextAll('.source').first().val(component.source);
+            node.nextAll('.mode').first().val(component.mode);
           });
         } else {
           // Make sure there is at least one component for convenience.
@@ -287,20 +282,17 @@
         // Reaction ID.
         if ('reactionIds' in query) {
           const reactionIds = $('#reaction_ids')
-          reactionIds.text(query.reactionIds.join(','));
+          reactionIds.val(query.reactionIds.join('\n'));
         }
 
         // Reaction SMILES.
         if ('reactionSmarts' in query) {
           const reactionSmarts = $('#reaction_smarts');
-          reactionSmarts.text(query.reactionSmarts);
+          reactionSmarts.val(query.reactionSmarts);
         }
 
         return query;
       }
-
-      // Make the .editext divs actually editable.
-      $('.edittext').attr('contentEditable', 'true');
 
       // Hook up the "+ component" button.
       $('#add_component').click(() => {

--- a/ord_interface/search.html
+++ b/ord_interface/search.html
@@ -45,7 +45,7 @@
         grid-row: controls;
         grid-row-gap: 18px;
         grid-column-gap: 18px;
-        grid-template-columns: [labels] 120px [text] 220px [source] auto [mode] auto;
+        grid-template-columns: [text] 220px [source] auto [mode] auto;
         align-items: center;
       }
       #reactions {
@@ -53,24 +53,12 @@
         grid-row: controls;
         grid-row-gap: 18px;
         grid-column-gap: 18px;
-        grid-template-columns: [labels] 120px [text] 220px;
+        grid-template-columns: [labels] auto [text] 220px;
         align-items: center;
       }
       .label {
         grid-column: labels;
         text-align: right;
-      }
-      .edittext, #similarity {
-        grid-column: text;
-      }
-      select {
-        grid-column: match;
-      }
-      #add_component {
-        grid-column: add;
-      }
-      #similarity {
-        grid-column: text;
       }
       #go {
         grid-row: go;
@@ -82,13 +70,6 @@
       #results {
         grid-column: results;
         font-family: monospace;
-      }
-      .edittext {
-        border: solid #c0c0c0;
-        border-width: 1px;
-        margin: 2px;
-        padding: 2px;
-        width: 200px;
       }
       .tab {
         padding: 2px 4px;
@@ -116,20 +97,19 @@
 
         <a href="#" id="add_component" style="grid-column: text">+ component</a>
 
-        <span class="label">use stereochemistry</span>
+        <span style="grid-column: text; text-align: right">use stereochemistry</span>
         <input type="checkbox" id="stereo">
 
-        <span class="label">similarity</span>
-        <div id="similarity"></div>
-        <span id="similarityText"></span>
+        <span style="grid-column: text; text-align: right">similarity threshold</span>
+        <input id="similarity" type="text" style="width: 60px">
       </div>
 
       <div id="reactions" style="display: none;">
         <span class="label">reaction IDs</span>
-        <div id="reaction_ids" class="edittext"></div>
+        <textarea id="reaction_ids"></textarea>
 
         <span class="label">reaction SMARTS</span>
-        <div id="reaction_smarts" class="edittext"></div>
+        <input id="reaction_smarts" type="text">
       </div>
 
       <div id="go">
@@ -145,7 +125,7 @@
     </div>
 
     <div id="component_template" style="display: none">
-      <div class="component edittext"></div>
+      <input style="grid-column: text" class="component" type="text">
       <select class="source" style="grid-column: source">
         <option value="input">input</option>
         <option value="output">output</option>
@@ -207,14 +187,14 @@
         return $('#stereo').is(":checked")
       }
 
-      // Get the current value of the similarity slider.
+      // Get the current value of the similarity threshold.
       function getSimilarity() {
-        return $('#similarity').slider('option', 'value');
+        return $('#similarity').text();
       }
 
-      // Set the value of the similarity slider.
+      // Set the value of the similarity threshold.
       function setSimilarity(similarity) {
-        $('#similarity').slider({min: 0, max: 100, value: 100 * similarity});
+        $('#similarity').text(similarity);
       }
 
       // Read back the user inputs and build a query URL.
@@ -322,13 +302,6 @@
       $('#go').click(() => {
         const path = exportQuery();
         window.location.href = path;
-      });
-
-      // Initialize the similarity slider.
-      similarity = $('#similarity').slider({min: 0, max: 100});
-      similarity.on('slidechange', () => {
-        const value = similarity.slider('option', 'value');
-        $('#similarityText').text((value / 100).toFixed(2));
       });
 
       // Hook up the tabs.

--- a/ord_interface/search.html
+++ b/ord_interface/search.html
@@ -45,7 +45,7 @@
         grid-row: controls;
         grid-row-gap: 18px;
         grid-column-gap: 18px;
-        grid-template-columns: [labels] 120px [text] 220px [match] 96px [add] 100px;
+        grid-template-columns: [labels] 120px [text] 220px [source] auto [mode] auto;
         align-items: center;
       }
       #reactions {
@@ -110,9 +110,11 @@
       </div>
 
       <div id="reagents">
-        <a href="#" id="add_component">+ component</a>
+        <span style="grid-column: text">SMILES/SMARTS</span>
+        <span>Source</span>
+        <span>Match mode</span>
 
-        <div></div> <!-- Blank grid cell to the right of the output. -->
+        <a href="#" id="add_component" style="grid-column: text">+ component</a>
 
         <span class="label">use stereochemistry</span>
         <input type="checkbox" id="stereo">
@@ -142,14 +144,13 @@
       <table id="results_table"></table>
     </div>
 
-    <div id="component_template" style="display: none;">
-      <span class="label">Component</span>
+    <div id="component_template" style="display: none">
       <div class="component edittext"></div>
-      <select class="source">
+      <select class="source" style="grid-column: source">
         <option value="input">input</option>
         <option value="output">output</option>
       </select>
-      <select class="component">
+      <select class="component" style="grid-column: mode">
         <option value="exact">exact</option>
         <option value="similar">similar</option>
         <option value="substructure">substructure</option>


### PR DESCRIPTION
* Condenses component information onto a single line
* Adds a header to the component fields
* Allows removal of component predicates
* Replaces the similarity threshold slider with a text input

![image](https://user-images.githubusercontent.com/952729/102002588-0ed01180-3cbb-11eb-920d-6e52a042dc8c.png)

![image](https://user-images.githubusercontent.com/952729/102002586-08419a00-3cbb-11eb-9861-26159cd04340.png)

