### PR TITLE
Refactor build_database{_test}.py to avoid COPY

### DIFF
--- a/ord_interface/build_database.py
+++ b/ord_interface/build_database.py
@@ -98,10 +98,10 @@ def _reactions_table(reaction: reaction_pb2.Reaction,
     cursor.execute(
         """
         INSERT INTO reactions
-        VALUES (%(reaction_id)s, 
-                %(reaction_smiles)s, 
-                %(doi)s, 
-                %(dataset_id)s, 
+        VALUES (%(reaction_id)s,
+                %(reaction_smiles)s,
+                %(doi)s,
+                %(dataset_id)s,
                 %(serialized)s);
         """, values)
 
@@ -114,7 +114,6 @@ def _inputs_table(reaction: reaction_pb2.Reaction,
         reaction: Reaction proto.
         cursor: psycopg2 cursor.
     """
-    rows = []
     for key in sorted(reaction.inputs):
         reaction_input = reaction.inputs[key]
         for compound in reaction_input.components:
@@ -125,7 +124,7 @@ def _inputs_table(reaction: reaction_pb2.Reaction,
                 continue
             cursor.execute(
                 """
-                INSERT INTO inputs 
+                INSERT INTO inputs
                 VALUES (%(reaction_id)s, %(smiles)s);
                 """, row)
 
@@ -138,7 +137,6 @@ def _outputs_table(reaction: reaction_pb2.Reaction,
         reaction: Reaction proto.
         cursor: psycopg2 cursor.
     """
-    rows = []
     for outcome in reaction.outcomes:
         for product in outcome.products:
             row = {'reaction_id': reaction.reaction_id}
@@ -153,7 +151,7 @@ def _outputs_table(reaction: reaction_pb2.Reaction,
                 continue
             cursor.execute(
                 """
-                INSERT INTO outputs 
+                INSERT INTO outputs
                 VALUES (%(reaction_id)s, %(smiles)s, %(yield)s);
                 """, row)
 

--- a/ord_interface/build_database.py
+++ b/ord_interface/build_database.py
@@ -90,7 +90,7 @@ def process_reaction(reaction: reaction_pb2.Reaction,
 
 
 def _reactions_table(reaction: reaction_pb2.Reaction,
-                     dataset_id: str) -> Mapping[str, Union[str, bytes]]:
+                     dataset_id: str) -> Mapping[str, Union[str, bytes, None]]:
     """Adds a Reaction to the 'reactions' table.
 
     Args:
@@ -140,8 +140,8 @@ def _inputs_table(reaction: reaction_pb2.Reaction) -> List[Mapping[str, str]]:
 
 
 def _outputs_table(
-        reaction: reaction_pb2.Reaction
-) -> List[Mapping[str, Union[str, float]]]:
+    reaction: reaction_pb2.Reaction
+) -> List[Mapping[str, Union[str, float, None]]]:
     """Adds rows to the 'outputs' table.
 
     Args:
@@ -158,11 +158,7 @@ def _outputs_table(
                 row['smiles'] = message_helpers.smiles_from_compound(product)
             except ValueError:
                 continue
-            product_yield = message_helpers.get_product_yield(product)
-            if product_yield is not None:
-                row['yield'] = product_yield
-            else:
-                continue
+            row['yield'] = message_helpers.get_product_yield(product)
             values.append(row)
     return values
 

--- a/ord_interface/build_database_test.py
+++ b/ord_interface/build_database_test.py
@@ -17,7 +17,6 @@ import os
 
 from absl.testing import absltest
 from absl.testing import flagsaver
-import pandas as pd
 import psycopg2
 
 from ord_schema import message_helpers

--- a/ord_interface/build_database_test.py
+++ b/ord_interface/build_database_test.py
@@ -18,11 +18,13 @@ import os
 from absl.testing import absltest
 from absl.testing import flagsaver
 import pandas as pd
+import psycopg2
 
 from ord_schema import message_helpers
 from ord_schema.proto import dataset_pb2
 from ord_schema.proto import reaction_pb2
 
+import ord_interface
 from ord_interface import build_database
 
 
@@ -30,6 +32,15 @@ class BuildDatabaseTest(absltest.TestCase):
 
     def setUp(self):
         super().setUp()
+        # NOTE(kearnes): ord-postgres is the hostname in docker-compose.
+        self.host = 'ord-postgres'
+        # Create a test database.
+        with self._connect(ord_interface.POSTGRES_DB) as connection:
+            connection.set_isolation_level(
+                psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+            with connection.cursor() as cursor:
+                cursor.execute('CREATE DATABASE test;')
+        # Create a test dataset.
         self.test_subdirectory = self.create_tempdir()
         reaction = reaction_pb2.Reaction()
         reaction.reaction_id = 'test'
@@ -47,49 +58,41 @@ class BuildDatabaseTest(absltest.TestCase):
         self.dataset = dataset_pb2.Dataset(dataset_id='test_dataset',
                                            reactions=[reaction])
         message_helpers.write_message(
-            self.dataset, os.path.join(self.test_subdirectory, 'test.pbtxt'))
+            self.dataset, os.path.join(self.test_subdirectory, 'test.pb'))
+
+    def tearDown(self):
+        # Remove the test database.
+        with self._connect(ord_interface.POSTGRES_DB) as connection:
+            connection.set_isolation_level(
+                psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+            with connection.cursor() as cursor:
+                cursor.execute('DROP DATABASE test;')
+
+    def _connect(self, dbname):
+        return psycopg2.connect(dbname=dbname,
+                                user=ord_interface.POSTGRES_USER,
+                                password=ord_interface.POSTGRES_PASSWORD,
+                                host=self.host,
+                                port=ord_interface.POSTGRES_PORT)
 
     def test_main(self):
-        input_pattern = os.path.join(self.test_subdirectory, '*.pbtxt')
-        output_dir = os.path.join(self.test_subdirectory, 'tables')
+        input_pattern = os.path.join(self.test_subdirectory, '*.pb')
         with flagsaver.flagsaver(input=input_pattern,
-                                 output=output_dir,
-                                 database=False,
-                                 cleanup=False):
+                                 dbname='test',
+                                 host=self.host):
             build_database.main(())
-        with open(os.path.join(output_dir, 'reactions.csv')) as f:
-            df = pd.read_csv(f)
-        # NOTE(kearnes): Map keys are not always serialized in the same order.
-        df['deserialized'] = df.serialized.apply(
-            lambda x: reaction_pb2.Reaction.FromString(bytes.fromhex(x)))
-        del df['serialized']
-        pd.testing.assert_frame_equal(
-            df,
-            pd.DataFrame({
-                'reaction_id': ['test'],
-                'reaction_smiles': ['reaction'],
-                'dataset_id': ['test_dataset'],
-                'doi': ['10.0000/test.foo'],
-                'deserialized': [self.dataset.reactions[0]],
-            }),
-            check_like=True)
-        with open(os.path.join(output_dir, 'inputs.csv')) as f:
-            df = pd.read_csv(f)
-        pd.testing.assert_frame_equal(
-            df,
-            pd.DataFrame({
-                'reaction_id': ['test', 'test', 'test'],
-                'smiles': ['input1', 'input2a', 'input2b'],
-            }))
-        with open(os.path.join(output_dir, 'outputs.csv')) as f:
-            df = pd.read_csv(f)
-        pd.testing.assert_frame_equal(
-            df,
-            pd.DataFrame({
-                'reaction_id': ['test'],
-                'smiles': ['product'],
-                'yield': [2.5]
-            }))
+        # Sanity checks.
+        with self._connect('test') as connection:
+            with connection.cursor() as cursor:
+                cursor.execute('SELECT * from reactions LIMIT 1;')
+                row = cursor.fetchone()
+                self.assertLen(row, 5)
+                cursor.execute('SELECT * from inputs LIMIT 1;')
+                row = cursor.fetchone()
+                self.assertLen(row, 2)
+                cursor.execute('SELECT * from outputs LIMIT 1;')
+                row = cursor.fetchone()
+                self.assertLen(row, 3)
 
 
 if __name__ == '__main__':

--- a/ord_interface/docker/build_database.sh
+++ b/ord_interface/docker/build_database.sh
@@ -23,3 +23,5 @@ fi
 
 python "${ORD_ROOT}/ord-interface/ord_interface/build_database.py" \
   --input="${ORD_INPUT}" "${ARGS}"
+# Reduce image size.
+rm -rf "${ORD_ROOT}"

--- a/ord_interface/docker/build_database.sh
+++ b/ord_interface/docker/build_database.sh
@@ -22,6 +22,4 @@ else
 fi
 
 python "${ORD_ROOT}/ord-interface/ord_interface/build_database.py" \
-  --input="${ORD_INPUT}" --output="${ORD_ROOT}/tables" --database "${ARGS}"
-# Reduce image size.
-rm -rf "${ORD_ROOT}"
+  --input="${ORD_INPUT}" "${ARGS}"

--- a/ord_interface/docker/update_image.sh
+++ b/ord_interface/docker/update_image.sh
@@ -20,8 +20,8 @@ docker build \
   -t ord-postgres:empty \
   . "$@"
 CONTAINER="$(docker run --rm -d ord-postgres:empty)"
-echo "Waiting 5s for the server to start..."
-sleep 5
+echo "Waiting for the server to start..."
+sleep 10
 TAG="${ORD_POSTGRES_TAG:-latest}"
 # NOTE(kearnes): Pass the tag directly instead of using ORD_POSTGRES_TAG
 # so we don't have to set that variable in the docker image.

--- a/ord_interface/search.py
+++ b/ord_interface/search.py
@@ -119,7 +119,7 @@ def fetch_reactions():
         dataset = connect().run_query(command)
         return flask.make_response(dataset.SerializeToString())
     except query.QueryException as error:
-        flask.abort(flask.make_response(str(error), 400))
+        return flask.abort(flask.make_response(str(error), 400))
 
 
 @app.route('/api/query')
@@ -131,12 +131,12 @@ def run_query():
     """
     command = build_query()
     if command is None:
-        flask.abort(flask.make_response('no query defined', 400))
+        return flask.abort(flask.make_response('no query defined', 400))
     try:
         dataset = connect().run_query(command)
         return flask.make_response(dataset.SerializeToString())
     except query.QueryException as error:
-        flask.abort(flask.make_response(str(error), 400))
+        return flask.abort(flask.make_response(str(error), 400))
 
 
 def build_query():

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -26,8 +26,8 @@ docker build -f Dockerfile -t openreactiondatabase/ord-interface ../ "$@"
 docker-compose up --detach
 set +x
 
-echo "Waiting 5s for the server to start..."
-sleep 5
+echo "Waiting for the server to start..."
+sleep 10
 
 set +e
 status=0


### PR DESCRIPTION
* The current script creates a CSV version of each table before importing it into postgres with `COPY`. This PR drop the intermediate CSV and writes directly to postgres.
* The test is updated to run some sanity checks on the resulting database; the actual content is tested elsewhere (e.g. in query_test.py).
* Misc. changes to support the new pylint version.