### PR TITLE
Use a more flexible return type for query results

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,7 +17,7 @@ name: Lint
 on: [pull_request, push]
 
 env:
-  ORD_SCHEMA_TAG: v0.3.11
+  ORD_SCHEMA_TAG: v0.3.12
 
 jobs:
   check_licenses:

--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ confidence=
 # --disable=W".
 disable=fixme,
         similarities,
-        too-few-public-methods
+        too-few-public-methods,
+        unspecified-encoding
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/ord_interface/Dockerfile
+++ b/ord_interface/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To build the interface using the current state of ord-schema:
-# $ cd path/to/ord-schema
+# To build the interface using the current state of ord-interface:
+# $ cd path/to/ord-interface/ord_interface
 # $ docker build \
-#     --file=ord_interface/Dockerfile \
+#     --file=Dockerfile \
 #     -t openreactiondatabase/ord-interface \
-#     .
+#     ..
 #
 # To push the built image to Docker Hub:
 # docker push openreactiondatabase/ord-interface

--- a/ord_interface/Dockerfile
+++ b/ord_interface/Dockerfile
@@ -42,7 +42,7 @@ RUN conda install -c rdkit \
 WORKDIR /usr/src/app
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
-ARG ORD_SCHEMA_TAG=v0.3.11
+ARG ORD_SCHEMA_TAG=v0.3.12
 RUN git fetch --tags && git checkout "${ORD_SCHEMA_TAG}"
 RUN pip install -r requirements.txt
 RUN python setup.py install

--- a/ord_interface/docker/Dockerfile
+++ b/ord_interface/docker/Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # To build an updated ord-postgres image containing the latest data:
-# $ cd path/to/ord-schema
-# $ ./docker/update_image.sh
+# $ cd path/to/ord-interface
+# $ ./ord_interface/docker/update_image.sh
 #
 # To push the built image to Docker Hub:
 # docker push openreactiondatabase/ord-postgres

--- a/ord_interface/docker/Dockerfile
+++ b/ord_interface/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN conda install -c rdkit \
 WORKDIR "${ORD_ROOT}"
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
-ARG ORD_SCHEMA_TAG=v0.3.11
+ARG ORD_SCHEMA_TAG=v0.3.12
 RUN git fetch --tags && git checkout "${ORD_SCHEMA_TAG}"
 RUN pip install -r requirements.txt
 RUN python setup.py install

--- a/ord_interface/ord_client_test.py
+++ b/ord_interface/ord_client_test.py
@@ -61,37 +61,37 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
                              expected)
 
     def test_query_dataset_ids(self):
-        dataset = self.client.query(dataset_ids=[
+        results = self.client.query(dataset_ids=[
             'ord_dataset-46ff9a32d9e04016b9380b1b1ef949c3',
             'ord_dataset-7d8f5fd922d4497d91cb81489b052746'
         ])
-        self.assertLen(dataset.reactions, 200)
+        self.assertLen(results, 200)
 
     def test_query_reaction_ids(self):
-        dataset = self.client.query(reaction_ids=[
+        results = self.client.query(reaction_ids=[
             'ord-f0621fa47ac74fd59f9da027f6d13fc4',
             'ord-c6fbf2aab30841d198a27068a65a9a98'
         ])
-        self.assertLen(dataset.reactions, 2)
+        self.assertLen(results, 2)
 
     def test_query_reaction_smarts(self):
-        dataset = self.client.query(
+        results = self.client.query(
             reaction_smarts='FC(F)(F)c1ccc([F,Cl,Br,I])cc1>CS(=O)C>')
-        self.assertLen(dataset.reactions, 21)
+        self.assertLen(results, 21)
 
     def test_query_dois(self):
         doi = '10.1021/acscatal.0c02247'
-        dataset = self.client.query(dois=[doi])
-        self.assertLen(dataset.reactions, 100)  # Downsampled size.
-        for reaction in dataset.reactions:
-            self.assertEqual(reaction.provenance.doi, doi)
+        results = self.client.query(dois=[doi])
+        self.assertLen(results, 100)  # Downsampled size.
+        for result in results:
+            self.assertEqual(result.reaction.provenance.doi, doi)
 
     def test_query_single_component(self):
         component = ord_client.ComponentQuery('FC(F)(F)c1ccc(Br)cc1',
                                               source='input',
                                               mode='exact')
-        dataset = self.client.query(components=[component])
-        self.assertLen(dataset.reactions, 7)
+        results = self.client.query(components=[component])
+        self.assertLen(results, 7)
 
     def test_query_multiple_components(self):
         component1 = ord_client.ComponentQuery('FC(F)(F)c1ccc(Br)cc1',
@@ -100,8 +100,8 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
         component2 = ord_client.ComponentQuery('CN(C)C(=NC(C)(C)C)N(C)C',
                                                source='input',
                                                mode='exact')
-        dataset = self.client.query(components=[component1, component2])
-        self.assertLen(dataset.reactions, 2)
+        results = self.client.query(components=[component1, component2])
+        self.assertLen(results, 2)
 
     def test_query_stereochemistry(self):
         # TODO(kearnes): Add a test once we have more chiral stuff.
@@ -111,8 +111,8 @@ class OrdClientTest(parameterized.TestCase, absltest.TestCase):
         component = ord_client.ComponentQuery('FC(F)(F)c1ccc(Br)cc1',
                                               source='input',
                                               mode='similar')
-        dataset = self.client.query(components=[component], similarity=0.6)
-        self.assertLen(dataset.reactions, 14)
+        results = self.client.query(components=[component], similarity=0.6)
+        self.assertLen(results, 14)
 
 
 if __name__ == '__main__':

--- a/ord_interface/query.py
+++ b/ord_interface/query.py
@@ -71,13 +71,6 @@ class Result:
         return reaction_pb2.Reaction.FromString(
             binascii.unhexlify(self.serialized))
 
-    def as_dict(self) -> Dict[str, str]:
-        return {
-            'dataset_id': self.dataset_id,
-            'reaction_id': self.reaction_id,
-            'serialized': self.serialized
-        }
-
 
 def fetch_results(cursor: psycopg2.extensions.cursor) -> List[Result]:
     """Fetches query results.

--- a/ord_interface/query_test.py
+++ b/ord_interface/query_test.py
@@ -36,33 +36,34 @@ class QueryTest(parameterized.TestCase, absltest.TestCase):
     def test_random_sample_query(self):
         command = query.RandomSampleQuery(16)
         results = self.postgres.run_query(command, return_ids=True)
-        self.assertLen(results.reaction_ids, 16)
+        self.assertLen(results, 16)
 
     def test_dataset_id_query(self):
         dataset_ids = ['ord_dataset-46ff9a32d9e04016b9380b1b1ef949c3']
         command = query.DatasetIdQuery(dataset_ids)
         results = self.postgres.run_query(command, limit=10, return_ids=True)
-        self.assertLen(results.reaction_ids, 10)
+        self.assertLen(results, 10)
 
     def test_reaction_id_query(self):
         reaction_ids = ['ord-e49ed67da61e4cddabd3c84a72fed227']
         command = query.ReactionIdQuery(reaction_ids)
-        results = self.postgres.run_query(command, limit=10, return_ids=True)
-        self.assertCountEqual(results.reaction_ids, reaction_ids)
+        results = self.postgres.run_query(command, limit=10, return_ids=False)
+        self.assertCountEqual([result.reaction_id for result in results],
+                              reaction_ids)
 
     def test_reaction_smarts_query(self):
         pattern = '[#6]>>[#7]'
         command = query.ReactionSmartsQuery(pattern)
         results = self.postgres.run_query(command, limit=10, return_ids=True)
-        self.assertLen(results.reaction_ids, 10)
+        self.assertLen(results, 10)
 
     def test_doi_query(self):
         dois = ['10.1021/acscatal.0c02247']
         command = query.DoiQuery(dois)
         results = self.postgres.run_query(command, limit=10)
-        self.assertLen(results.reactions, 10)
-        for reaction in results.reactions:
-            self.assertIn(reaction.provenance.doi, dois)
+        self.assertLen(results, 10)
+        for result in results:
+            self.assertIn(result.reaction.provenance.doi, dois)
 
     def test_substructure_query(self):
         pattern = 'C'
@@ -72,10 +73,10 @@ class QueryTest(parameterized.TestCase, absltest.TestCase):
         ]
         command = query.ReactionComponentQuery(predicates)
         results = self.postgres.run_query(command, limit=10, return_ids=True)
-        self.assertLen(results.reaction_ids, 10)
+        self.assertLen(results, 10)
         # Check that we remove redundant reaction IDs.
-        self.assertCountEqual(results.reaction_ids,
-                              np.unique(results.reaction_ids))
+        reaction_ids = [result.reaction_id for result in results]
+        self.assertCountEqual(reaction_ids, np.unique(reaction_ids))
 
     def test_smarts_query(self):
         pattern = '[#6]'
@@ -85,10 +86,10 @@ class QueryTest(parameterized.TestCase, absltest.TestCase):
         ]
         command = query.ReactionComponentQuery(predicates)
         results = self.postgres.run_query(command, limit=10, return_ids=True)
-        self.assertLen(results.reaction_ids, 10)
+        self.assertLen(results, 10)
         # Check that we remove redundant reaction IDs.
-        self.assertCountEqual(results.reaction_ids,
-                              np.unique(results.reaction_ids))
+        reaction_ids = [result.reaction_id for result in results]
+        self.assertCountEqual(reaction_ids, np.unique(reaction_ids))
 
     def test_similarity_query(self):
         pattern = 'CC=O'
@@ -99,14 +100,14 @@ class QueryTest(parameterized.TestCase, absltest.TestCase):
         command = query.ReactionComponentQuery(predicates,
                                                tanimoto_threshold=0.5)
         results = self.postgres.run_query(command, limit=10, return_ids=True)
-        self.assertEmpty(results.reaction_ids)
+        self.assertEmpty(results)
         command = query.ReactionComponentQuery(predicates,
                                                tanimoto_threshold=0.05)
         results = self.postgres.run_query(command, limit=10, return_ids=True)
-        self.assertLen(results.reaction_ids, 10)
+        self.assertLen(results, 10)
         # Check that we remove redundant reaction IDs.
-        self.assertCountEqual(results.reaction_ids,
-                              np.unique(results.reaction_ids))
+        reaction_ids = [result.reaction_id for result in results]
+        self.assertCountEqual(reaction_ids, np.unique(reaction_ids))
 
     def test_bad_smiles(self):
         pattern = 'invalid_smiles'

--- a/ord_interface/search.html
+++ b/ord_interface/search.html
@@ -398,9 +398,9 @@
       }
 
       const resultsData = [
-          {% if dataset -%}
-            {% for reaction_id in dataset.reaction_ids -%}
-              {"Reaction ID": "{{ reaction_id }}", "Summary": ""},
+          {% if results -%}
+            {% for result in results -%}
+              {"Reaction ID": "{{ result.reaction_id }}", "Summary": ""},
             {% endfor %}
           {% endif %}
       ];

--- a/ord_interface/search.py
+++ b/ord_interface/search.py
@@ -37,11 +37,11 @@ be URL-encoded.
 
 # pylint: disable=too-many-locals
 
+import json
 import os
 from typing import NewType, Optional, Tuple
 
 import flask
-import json
 
 from ord_schema.visualization import generate_text
 

--- a/ord_interface/search.py
+++ b/ord_interface/search.py
@@ -37,6 +37,7 @@ be URL-encoded.
 
 # pylint: disable=too-many-locals
 
+import dataclasses
 import json
 import os
 from typing import NewType, Optional, Tuple
@@ -121,7 +122,7 @@ def fetch_reactions():
     try:
         results = connect().run_query(command)
         return flask.make_response(
-            json.dumps([result.as_dict() for result in results]))
+            json.dumps([dataclasses.asdict(result) for result in results]))
     except query.QueryException as error:
         return flask.abort(flask.make_response(str(error), 400))
 
@@ -139,7 +140,7 @@ def run_query():
     try:
         results = connect().run_query(command, limit=limit)
         return flask.make_response(
-            json.dumps([result.as_dict() for result in results]))
+            json.dumps([dataclasses.asdict(result) for result in results]))
     except query.QueryException as error:
         return flask.abort(flask.make_response(str(error), 400))
 

--- a/ord_interface/search.py
+++ b/ord_interface/search.py
@@ -85,7 +85,8 @@ def show_id(reaction_id):
     results = connect().run_query(query.ReactionIdQuery([reaction_id]))
     if len(results) == 0:
         return flask.abort(404)
-    return generate_text.generate_summary(results[0].reaction)
+    return generate_text.generate_summary(reaction=results[0].reaction,
+                                          dataset_id=results[0].dataset_id)
 
 
 @app.route('/render/<reaction_id>')
@@ -98,7 +99,6 @@ def render_reaction(reaction_id):
     result = results[0]
     try:
         html = generate_text.generate_html(reaction=result.reaction,
-                                           dataset_id=result.dataset_id,
                                            compact=True)
         return flask.jsonify(html)
     except (ValueError, KeyError):

--- a/ord_interface/search.py
+++ b/ord_interface/search.py
@@ -41,6 +41,7 @@ import os
 from typing import NewType, Optional, Tuple
 
 import flask
+import json
 
 from ord_schema.visualization import generate_text
 
@@ -64,16 +65,16 @@ def show_root():
         command = query.RandomSampleQuery(100)
     query_json = command.json()
     try:
-        dataset = connect().run_query(command, limit=limit, return_ids=True)
+        results = connect().run_query(command, limit=limit, return_ids=True)
         error = None
     except query.QueryException as exception:
-        dataset = None
+        results = None
         error = f'(Error) {exception}'
-    if dataset is not None and not dataset.reaction_ids:
-        dataset = None
+    if results is not None and not results:
+        results = None
         error = 'query did not match any reactions'
     return flask.render_template('search.html',
-                                 dataset=dataset,
+                                 results=results,
                                  error=error,
                                  query=query_json)
 
@@ -81,22 +82,24 @@ def show_root():
 @app.route('/id/<reaction_id>')
 def show_id(reaction_id):
     """Returns the pbtxt of a single reaction as plain text."""
-    dataset = connect().run_query(query.ReactionIdQuery([reaction_id]))
-    if len(dataset.reactions) == 0:
+    results = connect().run_query(query.ReactionIdQuery([reaction_id]))
+    if len(results) == 0:
         return flask.abort(404)
-    return generate_text.generate_summary(dataset.reactions[0])
+    return generate_text.generate_summary(results[0].reaction)
 
 
 @app.route('/render/<reaction_id>')
 def render_reaction(reaction_id):
     """Renders a reaction as an HTML table with images and text."""
     command = query.ReactionIdQuery([reaction_id])
-    dataset = connect().run_query(command)
-    if len(dataset.reactions) == 0 or len(dataset.reactions) > 1:
+    results = connect().run_query(command)
+    if len(results) == 0 or len(results) > 1:
         return flask.abort(404)
-    reaction = dataset.reactions[0]
+    result = results[0]
     try:
-        html = generate_text.generate_html(reaction, compact=True)
+        html = generate_text.generate_html(reaction=result.reaction,
+                                           dataset_id=result.dataset_id,
+                                           compact=True)
         return flask.jsonify(html)
     except (ValueError, KeyError):
         return flask.jsonify('[Reaction cannot be displayed]')
@@ -116,8 +119,9 @@ def fetch_reactions():
     reaction_ids = flask.request.get_json()
     command = query.ReactionIdQuery(reaction_ids)
     try:
-        dataset = connect().run_query(command)
-        return flask.make_response(dataset.SerializeToString())
+        results = connect().run_query(command)
+        return flask.make_response(
+            json.dumps([result.as_dict() for result in results]))
     except query.QueryException as error:
         return flask.abort(flask.make_response(str(error), 400))
 
@@ -133,8 +137,9 @@ def run_query():
     if command is None:
         return flask.abort(flask.make_response('no query defined', 400))
     try:
-        dataset = connect().run_query(command, limit=limit)
-        return flask.make_response(dataset.SerializeToString())
+        results = connect().run_query(command, limit=limit)
+        return flask.make_response(
+            json.dumps([result.as_dict() for result in results]))
     except query.QueryException as error:
         return flask.abort(flask.make_response(str(error), 400))
 


### PR DESCRIPTION
* Exposes `dataset_id` for query results via a new `Result` container
* Passes the dataset ID to reaction landing pages in search results

Blocked by https://github.com/open-reaction-database/ord-schema/pull/611