### PR TITLE
Allow ord-interface to point to an arbitrary backend

### DIFF
--- a/copilot/front-end/manifest.yml
+++ b/copilot/front-end/manifest.yml
@@ -64,3 +64,4 @@ secrets:
   POSTGRES_HOST: /copilot/ord-interface/secrets/POSTGRES_HOST
   POSTGRES_USER: /copilot/ord-interface/secrets/POSTGRES_USER
   POSTGRES_PASSWORD: /copilot/ord-interface/secrets/POSTGRES_PASSWORD
+  POSTGRES_DATABASE: /copilot/ord-interface/secrets/POSTGRES_DATABASE

--- a/ord_interface/search.py
+++ b/ord_interface/search.py
@@ -52,6 +52,7 @@ POSTGRES_HOST = os.getenv('POSTGRES_HOST', 'localhost')
 POSTGRES_PORT = os.getenv('POSTGRES_PORT', '5432')
 POSTGRES_USER = os.getenv('POSTGRES_USER', 'ord-postgres')
 POSTGRES_PASSWORD = os.getenv('POSTGRES_PASSWORD', 'ord-postgres')
+POSTGRES_DATABASE = os.getenv('POSTGRES_DATABASE', 'ord')
 
 Query = NewType('Query', query.ReactionQueryBase)
 
@@ -109,7 +110,7 @@ def render_reaction(reaction_id):
 
 
 def connect():
-    return query.OrdPostgres(dbname='ord',
+    return query.OrdPostgres(dbname=POSTGRES_DATABASE,
                              user=POSTGRES_USER,
                              password=POSTGRES_PASSWORD,
                              host=POSTGRES_HOST,


### PR DESCRIPTION
Part of the fix for https://github.com/open-reaction-database/ord-schema/issues/617