### PR TITLE
Fix for exact search

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,7 +17,7 @@ name: Lint
 on: [pull_request, push]
 
 env:
-  ORD_SCHEMA_TAG: v0.3.14
+  ORD_SCHEMA_TAG: v0.3.15
 
 jobs:
   check_licenses:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -29,7 +29,7 @@ jobs:
         go-version: '>=1.16'
     - name: Install dependencies
       run: |
-        go get -v -u github.com/google/addlicense
+        go install github.com/google/addlicense@latest
     - name: addlicense
       run: |
         cd "${GITHUB_WORKSPACE}"

--- a/copilot/front-end/manifest.yml
+++ b/copilot/front-end/manifest.yml
@@ -40,7 +40,10 @@ image:
 cpu: 1024       # Number of CPU units for the task.
 memory: 2048    # Amount of memory in MiB used by the task.
 count:          # Number of tasks that should be running in your service.
-  range: 1-10
+  range:
+    min: 1
+    max: 10
+    spot_from: 1
   cpu_percentage: 70
   memory_percentage: 80
   requests: 10000

--- a/format.sh
+++ b/format.sh
@@ -19,7 +19,8 @@ set -ex
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # Add missing license headers.
 if command -v go &> /dev/null; then
-  go run github.com/google/addlicense@latest \
+  go install github.com/google/addlicense@latest
+  "${HOME}/go/bin/addlicense" \
     -c "Open Reaction Database Project Authors" \
     -l apache "${ROOT_DIR}"
 else

--- a/ord_interface/Dockerfile
+++ b/ord_interface/Dockerfile
@@ -42,7 +42,7 @@ RUN conda install -c rdkit \
 WORKDIR /usr/src/app
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
-ARG ORD_SCHEMA_TAG=v0.3.14
+ARG ORD_SCHEMA_TAG=v0.3.15
 RUN git fetch --tags && git checkout "${ORD_SCHEMA_TAG}"
 RUN pip install -r requirements.txt
 RUN python setup.py install

--- a/ord_interface/Dockerfile
+++ b/ord_interface/Dockerfile
@@ -42,7 +42,7 @@ RUN conda install -c rdkit \
 WORKDIR /usr/src/app
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
-ARG ORD_SCHEMA_TAG=v0.3.15
+ARG ORD_SCHEMA_TAG=v0.3.14
 RUN git fetch --tags && git checkout "${ORD_SCHEMA_TAG}"
 RUN pip install -r requirements.txt
 RUN python setup.py install

--- a/ord_interface/build_database.py
+++ b/ord_interface/build_database.py
@@ -141,7 +141,7 @@ def _inputs_table(reaction: reaction_pb2.Reaction) -> List[Mapping[str, str]]:
 
 
 def _outputs_table(
-        reaction: reaction_pb2.Reaction
+    reaction: reaction_pb2.Reaction
 ) -> List[Mapping[str, Union[str, float, None]]]:
     """Adds rows to the 'outputs' table.
 

--- a/ord_interface/build_database.py
+++ b/ord_interface/build_database.py
@@ -76,7 +76,6 @@ def process_reaction(reaction: reaction_pb2.Reaction,
 
     Args:
         reaction: Reaction proto.
-        cursor: psycopg2 cursor.
         dataset_id: Dataset ID.
 
     Returns:
@@ -142,7 +141,7 @@ def _inputs_table(reaction: reaction_pb2.Reaction) -> List[Mapping[str, str]]:
 
 
 def _outputs_table(
-    reaction: reaction_pb2.Reaction
+        reaction: reaction_pb2.Reaction
 ) -> List[Mapping[str, Union[str, float, None]]]:
     """Adds rows to the 'outputs' table.
 

--- a/ord_interface/docker/Dockerfile
+++ b/ord_interface/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN conda install -c rdkit \
 WORKDIR "${ORD_ROOT}"
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
-ARG ORD_SCHEMA_TAG=v0.3.14
+ARG ORD_SCHEMA_TAG=v0.3.15
 RUN git fetch --tags && git checkout "${ORD_SCHEMA_TAG}"
 RUN pip install -r requirements.txt
 RUN python setup.py install

--- a/ord_interface/query.py
+++ b/ord_interface/query.py
@@ -515,12 +515,11 @@ class ReactionComponentQuery(ReactionQueryBase):
         other_results = self._run(other, cursor=cursor, limit=limit)
         if exact_results and other_results:
             return list(set(exact_results).intersection(set(other_results)))
-        elif exact_results:
+        if exact_results:
             return exact_results
-        elif other_results:
+        if other_results:
             return other_results
-        else:
-            return []
+        return []
 
     def _run(self,
              predicates: List['ReactionComponentPredicate'],

--- a/ord_interface/query.py
+++ b/ord_interface/query.py
@@ -72,8 +72,8 @@ class Result:
             binascii.unhexlify(self.serialized))
 
     def __eq__(self, other: 'Result') -> bool:
-        return (self.dataset_id == other.dataset_id
-                and self.reaction_id == other.reaction_id)
+        return (self.dataset_id == other.dataset_id and
+                self.reaction_id == other.reaction_id)
 
 
 def fetch_results(cursor: psycopg2.extensions.cursor) -> List[Result]:
@@ -431,8 +431,7 @@ class ReactionComponentQuery(ReactionQueryBase):
             ],
         })
 
-    def _setup(self,
-               predicates: List['ReactionComponentPredicate'],
+    def _setup(self, predicates: List['ReactionComponentPredicate'],
                cursor: psycopg2.extensions.cursor) -> None:
         """Prepares the database for a query.
 
@@ -620,8 +619,10 @@ class ReactionComponentPredicate:
             predicate: sql.SQL query object.
             args: List of arguments for `predicate`.
         """
-        if self._mode in [ReactionComponentPredicate.MatchMode.SIMILAR,
-                          ReactionComponentPredicate.MatchMode.EXACT]:
+        if self._mode in [
+                ReactionComponentPredicate.MatchMode.SIMILAR,
+                ReactionComponentPredicate.MatchMode.EXACT
+        ]:
             predicate = sql.SQL('{}%%morganbv_fp(%s)').format(
                 sql.Identifier('rdk', self._table, 'mfp2'))
         elif self._mode == ReactionComponentPredicate.MatchMode.SUBSTRUCTURE:

--- a/ord_interface/query_test.py
+++ b/ord_interface/query_test.py
@@ -65,6 +65,19 @@ class QueryTest(parameterized.TestCase, absltest.TestCase):
         for result in results:
             self.assertIn(result.reaction.provenance.doi, dois)
 
+    def test_exact_query(self):
+        pattern = 'O=C1NC2=CC(Br)=CC3=C2N(C(CC(OC)=O)CC3)C1=O'
+        mode = query.ReactionComponentPredicate.MatchMode.EXACT
+        predicates = [
+            query.ReactionComponentPredicate(pattern, table='inputs', mode=mode)
+        ]
+        command = query.ReactionComponentQuery(predicates)
+        results = self.postgres.run_query(command, limit=5, return_ids=True)
+        self.assertLen(results, 5)
+        # Check that we remove redundant reaction IDs.
+        reaction_ids = [result.reaction_id for result in results]
+        self.assertCountEqual(reaction_ids, np.unique(reaction_ids))
+
     def test_substructure_query(self):
         pattern = 'C'
         mode = query.ReactionComponentPredicate.MatchMode.SUBSTRUCTURE


### PR DESCRIPTION
* Updates exact search to use similarity search with tanimoto threshold of 1.0; fixes #36 
* Not quite sure how to handle mixed exact and similarity search with the rdkit postgres cartridge (can only set the threshold once per query)