### PR TITLE
Fix Python version in Docker to be 3.9.15

### DIFF
--- a/ord_interface/Dockerfile
+++ b/ord_interface/Dockerfile
@@ -16,7 +16,7 @@
 # $ cd path/to/ord-interface/ord_interface
 # $ docker build --file=Dockerfile -t openreactiondatabase/ord-interface ..
 
-FROM python:3.9.15
+FROM python:3.9
 
 # default-jre is required for running the closure compiler linter.
 # For this next line, see:

--- a/ord_interface/Dockerfile
+++ b/ord_interface/Dockerfile
@@ -16,7 +16,7 @@
 # $ cd path/to/ord-interface/ord_interface
 # $ docker build --file=Dockerfile -t openreactiondatabase/ord-interface ..
 
-FROM python:latest
+FROM python:3.9.15
 
 # default-jre is required for running the closure compiler linter.
 # For this next line, see:


### PR DESCRIPTION
Using the updated version can lead to problems of installing of dependencies, e.g. there is no version of rdkit for the latest version of Python in Docker official image website.
