### PR TITLE
protobuf example (do not merge)

### DIFF
--- a/example/main.html
+++ b/example/main.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Protobuf Example</title>
+    <script src="https://code.jquery.com/jquery-3.6.3.min.js"
+            integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/ord-schema@0.3.41-rc2/dist/main.js"></script>
+</head>
+<body>
+<p>Protobuf Example</p>
+<div>
+    <button onclick="fetchReaction()">Fetch</button>
+    <div id="fetch"></div>
+</div>
+<div>
+    <button onclick="validateReaction()">Validate</button>
+    <div id="validate"></div>
+</div>
+<script>
+    function fetchReaction() {
+        return new Promise(resolve => {
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', 'http://localhost:5001/fetchReaction');
+            xhr.responseType = 'arraybuffer';
+            xhr.onload = function () {
+                console.log(xhr.response);
+                if (xhr.response !== null) {
+                    const bytes = new Uint8Array(xhr.response);
+                    const reaction = proto.ord.Reaction.deserializeBinary(bytes);
+                    $('#fetch').text(JSON.stringify({
+                        value: reaction.getIdentifiersList()[0].getValue(),
+                        type: reaction.getIdentifiersList()[0].getType()
+                    }));
+                }
+                resolve();
+            };
+            xhr.send(null);
+        });
+    }
+
+    function validateReaction() {
+        const reaction = new proto.ord.Reaction();
+        const identifier = reaction.addIdentifiers();
+        identifier.setValue('C(C)Cl.Br>>C(C)Br.Cl');
+        identifier.setType(proto.ord.ReactionIdentifier.ReactionIdentifierType.REACTION_SMILES);
+        return new Promise(resolve => {
+            const xhr = new XMLHttpRequest();
+            xhr.open('POST', 'http://localhost:5001/validateReaction');
+            const binary = reaction.serializeBinary();
+            xhr.responseType = 'json';
+            xhr.onload = function () {
+                console.log(xhr.response);
+                if (xhr.response !== null) {
+                    $('#validate').text(JSON.stringify(xhr.response));
+                }
+                resolve();
+            };
+            xhr.send(binary);
+        });
+    }
+</script>
+</body>
+</html>

--- a/example/main.py
+++ b/example/main.py
@@ -1,0 +1,29 @@
+"""Minimal flask example for ORD protocol buffers."""
+from flask import Flask, jsonify, make_response, render_template, request
+from ord_schema.proto import reaction_pb2
+from ord_schema.validations import ValidationOptions, validate_message
+
+app = Flask(__name__, template_folder=".")
+
+
+@app.route("/")
+def index():
+    return render_template("main.html")
+
+
+@app.route("/fetchReaction")
+def fetchReaction():
+    reaction = reaction_pb2.Reaction()
+    reaction.identifiers.add(value="C(C)Cl.Br>>C(C)Br.Cl", type="REACTION_SMILES")
+    response = make_response(reaction.SerializeToString())
+    response.headers.set("Content-Type", "application/protobuf")
+    return response
+
+
+@app.route("/validateReaction", methods=["POST"])
+def validate_reaction():
+    reaction = reaction_pb2.Reaction()
+    reaction.ParseFromString(request.get_data())
+    options = ValidationOptions(require_provenance=True)
+    output = validate_message(reaction, raise_on_error=False, options=options)
+    return jsonify({"errors": output.errors, "warnings": output.warnings})

--- a/example/run.sh
+++ b/example/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# npm install ord-schema@next
+flask --app main.py --debug run --port 5001


### PR DESCRIPTION
@mikennel hopefully this is useful?

There are a few ideas that are baked into the current editor design:
* We can build up protos on the JS side and then serialize them and send them over to python for validation. This example shows validation of an entire reaction, but we can send submessages as well.
* We can fetch and/or manipulate reactions in python and then serialize them and send them over to JS for display.