### PR TITLE
Make long running queries work on the frontend

### DIFF
--- a/app/src/views/search/MainSearch.vue
+++ b/app/src/views/search/MainSearch.vue
@@ -82,7 +82,7 @@ export default {
       if (options.reagent.reagents.length) {
         this.searchParams["component"] = []
         options.reagent.reagents.forEach(reagent => {
-          this.searchParams["component"].push(`${reagent.smileSmart};${reagent.source};${reagent.matchMode}`)
+          this.searchParams["component"].push(`${reagent.smileSmart};${reagent.source};${reagent.matchMode.toLowerCase()}`)
         })
 
         this.searchParams["use_stereochemistry"] = options.reagent.useStereochemistry
@@ -93,21 +93,21 @@ export default {
 
       // dataset options
       if (options.dataset.datasetIds.length)
-        this.searchParams["dataset_ids"] = options.dataset.datasetIds.join(",")
+        this.searchParams["dataset_id"] = options.dataset.datasetIds
       else
-        delete this.searchParams["dataset_ids"]
+        delete this.searchParams["dataset_id"]
       if (options.dataset.DOIs.length)
-        this.searchParams["dois"] = options.dataset.DOIs.join(",")
+        this.searchParams["doi"] = options.dataset.DOIs
       else
-        delete this.searchParams["dois"]
+        delete this.searchParams["doi"]
 
       // reaction options
       if (options.reaction.reactionIds.length)
-        this.searchParams["reaction_ids"] = options.reaction.reactionIds.join(",")
+        this.searchParams["reaction_id"] = options.reaction.reactionIds
       else
-        delete this.searchParams["reaction_ids"]
-      if (options.reaction.reactionSmarts.length)
-        this.searchParams["reaction_smarts"] = options.reaction.reactionSmarts.join(",")
+        delete this.searchParams["reaction_id"]
+      if (options.reaction.reactionSmarts)
+        this.searchParams["reaction_smarts"] = options.reaction.reactionSmarts
       else
         delete this.searchParams["reaction_smarts"]
       //yield and conversion add if not max values, otherwise remove from query

--- a/app/src/views/search/MainSearch.vue
+++ b/app/src/views/search/MainSearch.vue
@@ -58,10 +58,7 @@ export default {
         if (this.searchTaskId == null) {
           // Submit a search task to the server. This returns a GUID task ID.
           const taskres = await fetch(`/api/submit_query${this.urlQuery}`, {method: "GET"})
-          let searchTaskString = (await taskres.text());
-
-          // Remove double quotes
-          this.searchTaskId = searchTaskString.substring(1, searchTaskString.length-1);
+          this.searchTaskId = (await taskres.json());
         }
         // Check the status of the search task.
         const queryRes = await fetch(`/api/fetch_query_result?task_id=${this.searchTaskId}`, {method: "GET"})

--- a/app/src/views/search/MainSearch.vue
+++ b/app/src/views/search/MainSearch.vue
@@ -164,7 +164,7 @@ export default {
   async mounted() {
     // Fetch results. If server returns a 102, set up a poll to keep checking back until we have results.
     await this.getSearchResults().then(() =>{
-      if (this.searchLoadStatus?.status == 102) {
+      if (this.searchLoadStatus?.status == 102 && this.searchPollingInterval == null) {
         this.searchPollingInterval = setInterval(this.getSearchResults(), 1000);
         setTimeout(clearInterval(this.searchPollingInterval), 120000);
       }


### PR DESCRIPTION
This PR will make the new long-running queries API work with the ORD frontend.

Calls /submit_query, gets the task ID, then calls /fetch_query_result using that task ID continuously until results are returned.

Requests will be polled every 1 second for up to 2 minutes before ending attempts. We can always change these timings later if we want to query less or more often, or allow more time for a job to complete. The goal is to balance timely data with not overwhelming our server with polling requests.

Solution adapted from:
https://stackoverflow.com/questions/61683534/continuous-polling-of-backend-in-vue-js