### PR TITLE
125 Fixed issue in long running search polling on frontend

### DIFF
--- a/app/src/views/search/MainSearch.vue
+++ b/app/src/views/search/MainSearch.vue
@@ -87,14 +87,19 @@ export default {
         )
         .then(
           (searchResultsData) => {
-            // Deserialize the results.
-            this.searchResults = searchResultsData;
-            // unpack protobuff for each reaction in results
-            this.searchResults.forEach((reaction) => {
-                const bytes = base64ToBytes(reaction.proto)
-                reaction.data = reaction_pb.Reaction.deserializeBinary(bytes).toObject();
-              })
-            this.loading = false
+            // Only show the results if we have results - or lack of results.
+            // this.searchTaskId will be populated only if we're still polling
+            // If it is null, we're done polling - either the search ended in results, or an error.
+            if (this.searchTaskId == null) {
+              // Deserialize the results.
+              this.searchResults = searchResultsData;
+              // unpack protobuff for each reaction in results
+              this.searchResults.forEach((reaction) => {
+                  const bytes = base64ToBytes(reaction.proto)
+                  reaction.data = reaction_pb.Reaction.deserializeBinary(bytes).toObject();
+                })
+              this.loading = false
+            }
           }
         )
       } catch (e) {
@@ -162,11 +167,16 @@ export default {
     },
   },
   async mounted() {
-    // Fetch results. If server returns a 102, set up a poll to keep checking back until we have results.
+    // Fetch results. If server returns a 202, set up a poll to keep checking back until we have results.
     await this.getSearchResults().then(() =>{
-      if (this.searchLoadStatus?.status == 102 && this.searchPollingInterval == null) {
-        this.searchPollingInterval = setInterval(this.getSearchResults(), 1000);
-        setTimeout(clearInterval(this.searchPollingInterval), 120000);
+      if (this.searchLoadStatus?.status == 202 && this.searchPollingInterval == null) {
+        this.searchPollingInterval = setInterval(() => {this.getSearchResults()}, 1000);
+        setTimeout(() => {
+          clearInterval(this.searchPollingInterval)
+          this.searchTaskId = null
+          this.searchResults = []
+          this.loading = false
+        }, 120000);
       }
     })
   },

--- a/ord_interface/api/search.py
+++ b/ord_interface/api/search.py
@@ -245,6 +245,6 @@ async def fetch_query_result(task_id: str):
         return Response(f"Task {task_id} does not exist", status_code=status.HTTP_400_BAD_REQUEST)
     result = client.get(f"result:{task_id}")
     if result is None:
-        return Response(f"Task {task_id} is pending", status_code=status.HTTP_102_PROCESSING)
+        return Response(f"Task {task_id} is pending", status_code=202)
     with get_cursor() as cursor:
         return fetch_reactions(cursor, json.loads(result))


### PR DESCRIPTION
Addresses blockers on #125 and  #34 

Fixed the issue with long-running polling not working on the frontend. We swapped the HTTP return code for a 202. This PR includes the API change to return that code.

setInterval needs to be passed a JavaScript callback function, not just a JavaScript statement, which is what caused the issue. I tested by setting a sleep statement in the API and can confirm that the polling now continues every second until results are found (loads results or error immediately and stops polling) or until 2 minutes is up (loads error)

Also, each poll was causing the UI to show the loading icon and No Results between each poll, so I have fixed this by not attempting to load any results or messages until we're finishing polling.