### PR TITLE
Fix API call in DownloadResults to use reaction_ids in line with updates to the API and throw in formatting fix to modal title

### DIFF
--- a/app/src/components/DownloadResults.vue
+++ b/app/src/components/DownloadResults.vue
@@ -58,7 +58,7 @@ export default {
         }
       };
       xhr.setRequestHeader('Content-Type', 'application/json');
-      xhr.send(JSON.stringify({"reaction_id": this.reactionIds}));
+      xhr.send(JSON.stringify({"reaction_ids": this.reactionIds}));
     }
   },
   mounted() {
@@ -71,7 +71,7 @@ export default {
 .download-results-main
   floating-modal(
       v-if='showDownloadResults'
-      title="DownloadResults"
+      title="Download Results"
       @closeModal='$emit("hideDownloadResults")'
     )
       .download-body


### PR DESCRIPTION
Closes #144 

Fixed the API call from the Download Results button, just a schema mismatch between reaction_id and reaction_ids
Also fixed the Download modal title from DownloadResults to Download Results