### PR TITLE
Fix reactions parameter name in selected view

### DIFF
--- a/app/src/views/browse/selected-set/MainSelectedSet.vue
+++ b/app/src/views/browse/selected-set/MainSelectedSet.vue
@@ -65,7 +65,7 @@ export default {
           this.reactions = fetchedReactions
           this.loading = false
         }
-        xhr.send(JSON.stringify({"reaction_id": this.reactionIds}))
+        xhr.send(JSON.stringify({"reaction_ids": this.reactionIds}))
       } catch (e) {
         console.log(e)
         this.loading = false


### PR DESCRIPTION
Followup for the #126 
Original fix did not include another place in the application where the same api call was used.

STR:
* Open the app.
* Open any dataset and select reaction via "Select reaction checkbox"
* Click "View 1 selected reactions" button at the bottom right of the screen
* "Reaction Set" page will be infinitely loading instead of displaying information about selected reaction

*Before*
![Screenshot 2024-11-05 163818](https://github.com/user-attachments/assets/7915f305-9dd0-4744-bbdc-7b90bfa09f43)

*After*
![Screenshot 2024-11-05 163710](https://github.com/user-attachments/assets/b200bb5f-1298-4673-827e-d2b16a06a05d)

Fix is similar to the one in #132 
