### PR TITLE
Convert reactionIds to a list from a string as expected by API

### DIFF
--- a/app/src/views/browse/selected-set/MainSelectedSet.vue
+++ b/app/src/views/browse/selected-set/MainSelectedSet.vue
@@ -38,7 +38,7 @@ export default {
   },
   computed: {
     reactionIds() {
-      return this.$route.query.reaction_id || []
+      return [this.$route.query.reaction_id] || []
     },
     fullUrl() {
       return window.location.href


### PR DESCRIPTION
While testing https://github.com/open-reaction-database/ord-interface/pull/147 I found that the Shareable Link for any selected set does not load. The fix is to set the computed reactionIds property to a list of reactionIds as expected by the API, not a string