### PR TITLE
Fixed bug with dataset results disappearing after 2 minutes

### DIFF
--- a/app/src/views/dataset-view/MainDatasetView.vue
+++ b/app/src/views/dataset-view/MainDatasetView.vue
@@ -185,7 +185,6 @@ export default {
         setTimeout(() => {
           clearInterval(this.searchPollingInterval)
           this.searchTaskId = null
-          this.searchResults = []
           this.loading = false
         }, 120000);
       }


### PR DESCRIPTION
After fixing #150 I realized the same error can occur in the new dataset viewer, so here is the fix!