### PR TITLE
app: adopt ord-app UI styling (#171 rebased + cleaned up)

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -45,25 +45,27 @@ export default {
 @use '@/styles/vars' as *
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap')
 body
-  font-family: 'Roboto', sans-serif
+  font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif
   margin: 0
 #app, #main-container
   min-height: 100vh
 #main-container
   display: grid
   grid-template-rows: auto 1fr auto
-  background-color: $lightgrey
+  background-color: $color-background-main
   min-width: 800px
   &.full-height
     grid-template-rows: 1fr
 
 button
-  background-color: $linkblue
+  background-color: $color-primary
   border: none
   color: white
   border-radius: 0.25rem
   cursor: pointer
   padding: 0.25rem 0.5rem
+  &:hover
+    background-color: $color-text-hover
 
 // multi-value-slider styles
 .multi-range-slider
@@ -74,10 +76,10 @@ button
     width: 18px !important
     margin: -5px !important
     box-shadow: none !important
-    background-color: #0d6efd !important
+    background-color: $color-primary !important
   .bar-left, .bar-inner, .bar-right
     box-shadow: none !important
     border: grey 1px solid
   .bar-inner
-    background-color: #0d6efd !important
+    background-color: $color-primary !important
 </style>

--- a/app/src/components/CopyButton.vue
+++ b/app/src/components/CopyButton.vue
@@ -84,7 +84,7 @@ export default {
       font-size: 1rem
   #copy-notification
     position: fixed
-    background-color: $darkgrey
+    background-color: $color-shadow-2
     color: white
     padding: 0.5rem 1rem
     border-radius: 0.25rem

--- a/app/src/components/EntityTable.vue
+++ b/app/src/components/EntityTable.vue
@@ -163,6 +163,7 @@ export default {
 
 .table-main
   width: 100%
+  background-color: $lightgrey
   .table-container
     width: 100%
     .header
@@ -174,9 +175,16 @@ export default {
     .search-area
       padding: 1rem
       margin: 0 5%
+      background-color: white
+      border-radius: .5rem
+      border: 1px solid $color-border-1
+      margin-bottom: .5rem
       input
         width: 30%
         min-width: 300px
+        border: 1px solid $color-border-1
+        border-radius: 0.25rem
+        margin-left: 0.5rem
     .content
       width: 100%
       height: fit-content

--- a/app/src/components/EntityTable.vue
+++ b/app/src/components/EntityTable.vue
@@ -163,7 +163,7 @@ export default {
 
 .table-main
   width: 100%
-  background-color: $lightgrey
+  background-color: $color-background-main
   .table-container
     width: 100%
     .header
@@ -214,7 +214,7 @@ export default {
         column-gap: 2rem
         padding: 1rem
         margin: 0 5%
-        color: $linkblue
+        color: $color-primary
         .select
           color: black
         .paginav
@@ -225,7 +225,7 @@ export default {
           cursor: pointer
           transition: .25s
           &:hover
-            color: $hoverblue
+            color: $color-text-hover
           &.prev, &.next
             grid-template-columns: auto 1fr
           &.first, &.last

--- a/app/src/components/HeaderNav.vue
+++ b/app/src/components/HeaderNav.vue
@@ -33,8 +33,9 @@ nav.navbar.navbar-expand-lg.bg-light
           router-link.nav-link(:to='{name: "browse"}') Browse
           router-link.nav-link(:to='{name: "search"}') Search
         .nav-item
-          a.nav-link(href="https://app.open-reaction-database.org") Contribute
-          a.nav-link(href="https://docs.open-reaction-database.org") Docs
+          .nav-item
+            a.nav-link(href="https://app.open-reaction-database.org/datasets" target="_blank") Contribute
+            a.nav-link(href="https://docs.open-reaction-database.org" target="_blank") Docs
         .nav-item
           router-link.nav-link(:to='{name: "about"}') About
 </template>
@@ -44,6 +45,7 @@ nav.navbar.navbar-expand-lg.bg-light
 
 nav
   background-color: white !important
+  border-bottom: 1px solid $color-border-1
   .container
     display: flex
     flex-wrap: inherit

--- a/app/src/components/HeaderNav.vue
+++ b/app/src/components/HeaderNav.vue
@@ -65,7 +65,7 @@ nav
             padding: 0.5rem
             text-decoration: none
             transition: .15s
-            color: $linkblue
+            color: $color-primary
             &:hover
-              color: $hoverblue
+              color: $color-text-hover
 </style>

--- a/app/src/components/LoadingSpinner.vue
+++ b/app/src/components/LoadingSpinner.vue
@@ -55,10 +55,10 @@ export default {
       width: 64px
       height: 64px
       margin: 8px
-      border: 8px solid $linkblue
+      border: 8px solid $color-primary
       border-radius: 50%
       animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite
-      border-color: $linkblue transparent transparent transparent
+      border-color: $color-primary transparent transparent transparent
       &:nth-child(1)
         animation-delay: -0.45s
       &:nth-child(2)

--- a/app/src/components/ReactionCard.vue
+++ b/app/src/components/ReactionCard.vue
@@ -199,5 +199,5 @@ export default {
           overflow: hidden
           text-overflow: ellipsis
     &.selected
-      border-color: $linkblue
+      border-color: $color-primary
 </style>

--- a/app/src/components/ReactionCard.vue
+++ b/app/src/components/ReactionCard.vue
@@ -171,8 +171,8 @@ export default {
     .is-mined-badge
       text-align: center
       border-radius: 5px
-      background-color: #0d6efd
-      color: #fff
+      background-color: $color-primary
+      color: $color-background-white
       font-size: 0.8rem
       width: 60px
     .info

--- a/app/src/components/ReactionCard.vue
+++ b/app/src/components/ReactionCard.vue
@@ -158,7 +158,7 @@ export default {
     transition: 0.25s
     border: 4px solid white
     &:hover
-      box-shadow: 0 0 5px $darkgrey
+      box-shadow: 0 0 5px $color-shadow-2
     .select
       input, label
         cursor: pointer

--- a/app/src/styles/table.sass
+++ b/app/src/styles/table.sass
@@ -21,12 +21,13 @@
     background-color: white
     width: 90%
     margin: auto
+    border: 1px solid $color-border-1
     border-radius: 0.5rem
     display: grid
     overflow: hidden
     display: grid
     .column
-      border-top: 1px solid $medgrey
+      border-top: 1px solid $color-border-1
       padding: 0.5rem
       &.label
         border-top: none

--- a/app/src/styles/tabs.sass
+++ b/app/src/styles/tabs.sass
@@ -24,7 +24,7 @@
   .tab
     padding: 0.5rem 1rem
     border-radius: 0.25rem
-    border: 1px solid $medgrey
+    border: 1px solid $color-border-1
     cursor: pointer
     transition: 0.25s
     &.selected

--- a/app/src/styles/tabs.sass
+++ b/app/src/styles/tabs.sass
@@ -28,9 +28,9 @@
     cursor: pointer
     transition: 0.25s
     &.selected
-      background-color: $linkblue
+      background-color: $color-primary
       color: white
-      border-color: $linkblue
+      border-color: $color-primary
       cursor: default
     &.capitalize
       text-transform: capitalize

--- a/app/src/styles/vars.sass
+++ b/app/src/styles/vars.sass
@@ -14,8 +14,193 @@
  * limitations under the License.
  */
 
-$lightgrey: #f8f9fa
-$medgrey: #e8e9e3
+// Original colors (updated to match ord-app)
+$lightgrey: #f8f8f8
+$medgrey: #868e96
 $darkgrey: #a0a0a0
-$linkblue: #0d6efd
-$hoverblue: #0a58ca
+$linkblue: #3C78D8
+$hoverblue: #ff8d00
+
+// ORD-app specific colors  
+$color-primary: #3c78d8
+$color-background-main: #f8f8f8
+$color-background-gray: #e8ebed
+$color-background-dark-gray: #2f2f2f
+$color-background-white: #fff
+$color-text-primary: #090a0b
+$color-text-hover: #ff8d00
+$color-text-secondary-1: #aab9c5
+$color-text-secondary-2: #637d92
+$color-text-secondary-3: #4a5e6d
+$color-border-1: #e8ebed
+$color-border-2: #d2d6db
+$color-icons-default: #637d92
+$color-shadow-1: #7c7c7c
+
+// Dark colors
+$dark-0: #c9c9c9
+$dark-1: #b8b8b8
+$dark-2: #828282
+$dark-3: #696969
+$dark-4: #424242
+$dark-5: #3b3b3b
+$dark-6: #2e2e2e
+$dark-7: #242424
+$dark-8: #1f1f1f
+$dark-9: #141414
+
+// Gray colors
+$gray-0: #f8f9fa
+$gray-1: #f1f3f5
+$gray-2: #e9ecef
+$gray-3: #dee2e6
+$gray-4: #ced4da
+$gray-5: #adb5bd
+$gray-6: #868e96
+$gray-7: #495057
+$gray-8: #343a40
+$gray-9: #212529
+
+// Red colors
+$red-0: #fff5f5
+$red-1: #ffe3e3
+$red-2: #ffc9c9
+$red-3: #ffa8a8
+$red-4: #ff8787
+$red-5: #ff6b6b
+$red-6: #fa5252
+$red-7: #f03e3e
+$red-8: #e03131
+$red-9: #c92a2a
+
+// Pink colors
+$pink-0: #fff0f6
+$pink-1: #ffdeeb
+$pink-2: #fcc2d7
+$pink-3: #faa2c1
+$pink-4: #f783ac
+$pink-5: #f06595
+$pink-6: #e64980
+$pink-7: #d6336c
+$pink-8: #c2255c
+$pink-9: #a61e4d
+
+// Grape colors
+$grape-0: #f8f0fc
+$grape-1: #f3d9fa
+$grape-2: #eebefa
+$grape-3: #e599f7
+$grape-4: #da77f2
+$grape-5: #cc5de8
+$grape-6: #be4bdb
+$grape-7: #ae3ec9
+$grape-8: #9c36b5
+$grape-9: #862e9c
+
+// Violet colors
+$violet-0: #f3f0ff
+$violet-1: #e5dbff
+$violet-2: #d0bfff
+$violet-3: #b197fc
+$violet-4: #9775fa
+$violet-5: #845ef7
+$violet-6: #7950f2
+$violet-7: #7048e8
+$violet-8: #6741d9
+$violet-9: #5f3dc4
+
+// Indigo colors
+$indigo-0: #edf2ff
+$indigo-1: #dbe4ff
+$indigo-2: #bac8ff
+$indigo-3: #91a7ff
+$indigo-4: #748ffc
+$indigo-5: #5c7cfa
+$indigo-6: #4c6ef5
+$indigo-7: #4263eb
+$indigo-8: #3b5bdb
+$indigo-9: #364fc7
+
+// Blue colors
+$blue-0: #e7f5ff
+$blue-1: #d0ebff
+$blue-2: #a5d8ff
+$blue-3: #74c0fc
+$blue-4: #4dabf7
+$blue-5: #339af0
+$blue-6: #228be6
+$blue-7: #1c7ed6
+$blue-8: #1971c2
+$blue-9: #1864ab
+
+// Cyan colors
+$cyan-0: #e3fafc
+$cyan-1: #c5f6fa
+$cyan-2: #99e9f2
+$cyan-3: #66d9e8
+$cyan-4: #3bc9db
+$cyan-5: #22b8cf
+$cyan-6: #15aabf
+$cyan-7: #1098ad
+$cyan-8: #0c8599
+$cyan-9: #0b7285
+
+// Teal colors
+$teal-0: #e6fcf5
+$teal-1: #c3fae8
+$teal-2: #96f2d7
+$teal-3: #63e6be
+$teal-4: #38d9a9
+$teal-5: #20c997
+$teal-6: #12b886
+$teal-7: #0ca678
+$teal-8: #099268
+$teal-9: #087f5b
+
+// Green colors
+$green-0: #ebfbee
+$green-1: #d3f9d8
+$green-2: #b2f2bb
+$green-3: #8ce99a
+$green-4: #69db7c
+$green-5: #51cf66
+$green-6: #40c057
+$green-7: #37b24d
+$green-8: #2f9e44
+$green-9: #2b8a3e
+
+// Lime colors
+$lime-0: #f4fce3
+$lime-1: #e9fac8
+$lime-2: #d8f5a2
+$lime-3: #c0eb75
+$lime-4: #a9e34b
+$lime-5: #94d82d
+$lime-6: #82c91e
+$lime-7: #74b816
+$lime-8: #66a80f
+$lime-9: #5c940d
+
+// Yellow colors
+$yellow-0: #fff9db
+$yellow-1: #fff3bf
+$yellow-2: #ffec99
+$yellow-3: #ffe066
+$yellow-4: #ffd43b
+$yellow-5: #fcc419
+$yellow-6: #fab005
+$yellow-7: #f59f00
+$yellow-8: #f08c00
+$yellow-9: #e67700
+
+// Orange colors
+$orange-0: #fff4e6
+$orange-1: #ffe8cc
+$orange-2: #ffd8a8
+$orange-3: #ffc078
+$orange-4: #ffa94d
+$orange-5: #ff922b
+$orange-6: #fd7e14
+$orange-7: #f76707
+$orange-8: #e8590c
+$orange-9: #d9480f

--- a/app/src/styles/vars.sass
+++ b/app/src/styles/vars.sass
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-$darkgrey: #a0a0a0
-
 // ORD-app colors
 $color-primary: #3c78d8
 $color-background-main: #f8f8f8
@@ -31,6 +29,7 @@ $color-border-1: #e8ebed
 $color-border-2: #d2d6db
 $color-icons-default: #637d92
 $color-shadow-1: #7c7c7c
+$color-shadow-2: #a0a0a0
 
 // Dark colors
 $dark-0: #c9c9c9

--- a/app/src/styles/vars.sass
+++ b/app/src/styles/vars.sass
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-// Original colors (updated to match ord-app)
-$lightgrey: #f8f8f8
-$medgrey: #868e96
 $darkgrey: #a0a0a0
-$linkblue: #3C78D8
-$hoverblue: #ff8d00
 
-// ORD-app specific colors  
+// ORD-app colors
 $color-primary: #3c78d8
 $color-background-main: #f8f8f8
 $color-background-gray: #e8ebed

--- a/app/src/views/About.vue
+++ b/app/src/views/About.vue
@@ -27,7 +27,7 @@ export default {
     class="container"
   >
     <div class="row mt-5">
-      <div class="col-3 border-top pt-3">
+      <div class="col-3 pt-3">
         <h3>About</h3>
       </div>
       <div class="col-9 p-3">
@@ -68,7 +68,7 @@ export default {
       <div class="col-3 border-top pt-3">
         <h3>Publications and Media</h3>
       </div>
-      <div class="col-9 p-3">
+      <div class="col-9 border-top p-3">
         <h5>Journal Articles</h5>
         <ul>
           <li>
@@ -119,7 +119,7 @@ export default {
       <div class="col-3 border-top pt-3">
         <h3>Leadership</h3>
       </div>
-      <div class="col-9 p-3">
+      <div class="col-9 border-top p-3">
         <h5>Governing Committee</h5>
         <div class="row">
           <div class="col-6">
@@ -172,7 +172,7 @@ export default {
       <div class="col-3 border-top pt-3">
         <h3>Support</h3>
       </div>
-      <div class="col-9 p-3">
+      <div class="col-9 border-top p-3">
         <p>We gratefully acknowledge support from:</p>
         <ul>
           <li>Google</li>
@@ -186,9 +186,11 @@ export default {
 </template>
 
 <style lang="sass" scoped>
+@import '@/styles/vars'
 #about
   margin-top: 2rem
   background-color: white
   padding: 0 2rem
   border-radius: 0.5rem
+  border: 1px solid $color-border-1
 </style>

--- a/app/src/views/dataset-view/MainDatasetView.vue
+++ b/app/src/views/dataset-view/MainDatasetView.vue
@@ -282,7 +282,7 @@ export default {
         width: 90%
         height: 100%
         overflow-y: auto
-        box-shadow: 0 0 5px $darkgrey
+        box-shadow: 0 0 5px $color-shadow-2
       .slide-out-tab
         background-color: white
         position: absolute

--- a/app/src/views/dataset-view/SearchResults.vue
+++ b/app/src/views/dataset-view/SearchResults.vue
@@ -160,7 +160,7 @@ export default {
             overflow: hidden
             text-overflow: ellipsis
       &.selected
-        border-color: $linkblue
+        border-color: $color-primary
   .view-selected-container
     position: fixed
     bottom: 2rem
@@ -168,7 +168,7 @@ export default {
     .view-selected-button
       padding: 0.5rem 1rem
       color: white
-      background-color: $linkblue
+      background-color: $color-primary
       border-radius: 0.25rem
       cursor: pointer
       box-shadow: 0 0 5px $darkgrey

--- a/app/src/views/dataset-view/SearchResults.vue
+++ b/app/src/views/dataset-view/SearchResults.vue
@@ -129,7 +129,7 @@ export default {
       transition: 0.25s
       border: 4px solid white
       &:hover
-        box-shadow: 0 0 5px $darkgrey
+        box-shadow: 0 0 5px $color-shadow-2
       .select
         input, label
           cursor: pointer
@@ -171,7 +171,7 @@ export default {
       background-color: $color-primary
       border-radius: 0.25rem
       cursor: pointer
-      box-shadow: 0 0 5px $darkgrey
+      box-shadow: 0 0 5px $color-shadow-2
       animation: bounce 5s infinite ease-in-out
       @keyframes bounce
         0%, 20%

--- a/app/src/views/reaction-view/CompoundView.vue
+++ b/app/src/views/reaction-view/CompoundView.vue
@@ -172,7 +172,7 @@ export default {
   .raw
     .button
       padding: 0.5rem
-      background-color: $darkgrey
+      background-color: $color-shadow-2
       color: white
       border-radius: 0.25rem
       cursor: pointer

--- a/app/src/views/reaction-view/MainReactionView.vue
+++ b/app/src/views/reaction-view/MainReactionView.vue
@@ -377,7 +377,7 @@ export default {
         color: black
         &.active
           color: white
-          background-color: $linkblue
+          background-color: $color-primary
 .loading
   position: absolute
   width: 100%
@@ -418,7 +418,7 @@ export default {
       width: fit-content
   .full-record.button
     padding: 0.5rem 1rem
-    background-color: $linkblue
+    background-color: $color-primary
     border-radius: 0.25rem
     width: fit-content
     color: white

--- a/app/src/views/reaction-view/OutcomesView.vue
+++ b/app/src/views/reaction-view/OutcomesView.vue
@@ -215,7 +215,7 @@ export default {
     .raw
       .button
         padding: 0.5rem
-        background-color: $darkgrey
+        background-color: $color-shadow-2
         color: white
         border-radius: 0.25rem
         cursor: pointer

--- a/app/src/views/reaction-view/OutcomesView.vue
+++ b/app/src/views/reaction-view/OutcomesView.vue
@@ -194,7 +194,7 @@ export default {
       display: flex
       align-items: center
   .sub-section
-    border: 1px solid $medgrey
+    border: 1px solid $gray-6
     border-radius: 0.25rem
     padding: 1rem
     .compound

--- a/app/src/views/search/MainSearch.vue
+++ b/app/src/views/search/MainSearch.vue
@@ -270,7 +270,7 @@ export default {
         width: 90%
         height: 100%
         overflow-y: auto
-        box-shadow: 0 0 5px $darkgrey
+        box-shadow: 0 0 5px $color-shadow-2
       .slide-out-tab
         background-color: white
         position: absolute

--- a/app/src/views/search/MainSearch.vue
+++ b/app/src/views/search/MainSearch.vue
@@ -230,14 +230,15 @@ export default {
   width: 95%
   margin: 1rem 2.5%
   display: grid
-  grid-template-columns: auto 1fr
+  grid-template-columns: 400px 1fr
   column-gap: 1rem
   min-width: 800px
   .search-options-container
     .title
-      font-size: 2rem
-      font-weight: 700
+      font-size: 13px
+      font-weight: 500
       margin-bottom: 0.85rem
+      font-family: 'Roboto', Helvetica, Arial, sans-serif
     .options-holder
       position: -webkit-sticky
       position: sticky
@@ -246,6 +247,7 @@ export default {
       padding: 1rem
       box-sizing: border-box
       border-radius: 0.25rem
+      border: 1px solid $color-border-1
       overflow-y: auto
   .no-results
     margin-top: 1rem

--- a/app/src/views/search/SearchOptions.vue
+++ b/app/src/views/search/SearchOptions.vue
@@ -29,9 +29,9 @@ export default {
   data() {
     return {
       test: null,
-      showReagentOptions: false,
-      showReactionOptions: false,
-      showDatasetOptions: false,
+      showReagentOptions: true,
+      showReactionOptions: true,
+      showDatasetOptions: true,
       reagentOptions: {
         reactants: [],
         products: [],
@@ -172,7 +172,7 @@ export default {
     :class='showReagentOptions ? "" : "closed"'
   ) 
     span Components
-    i.material-icons expand_less
+    //- i.material-icons expand_less
   transition(name="expand")
     #searchByReagent.options-container(
       v-if='showReagentOptions'
@@ -255,7 +255,7 @@ export default {
     :class='showReactionOptions ? "" : "closed"'
   ) 
     span Reactions
-    i.material-icons expand_less
+    //- i.material-icons expand_less
   transition(name="expand")
     #searchByReaction.options-container(
       v-if='showReactionOptions'
@@ -301,7 +301,7 @@ export default {
     :class='showDatasetOptions ? "" : "closed"'
   ) 
     span Datasets
-    i.material-icons expand_less
+    //- i.material-icons expand_less
   transition(name="expand")
     #searchByDataset.options-container(
       v-if='showDatasetOptions'
@@ -341,14 +341,14 @@ ModalKetcher(
 @use '@/styles/transition' as *
 @use '@/styles/tabs' as *
 .search-options
-  max-height: 90vh
+  max-height: 900vh
   .options-title
-    font-size: 1.5rem
-    font-weight: 700
+    font-size: 1 rem
+    font-family: 'Roboto', Helvetica, Arial, sans-serif
+    font-weight: 500
     cursor: pointer
     padding: 0.5rem 1rem
-    border-top-left-radius: 0.25rem
-    border-top-right-radius: 0.25rem
+    border-radius: 0.25rem
     margin-top: 1rem
     color: white
     background-color: $linkblue
@@ -371,13 +371,11 @@ ModalKetcher(
       cursor: default
   .options-container
     background-color: white
-    border-bottom-left-radius: 0.25rem
-    border-bottom-right-radius: 0.25rem
+    border-radius: 0.25rem
     padding: 1rem
     margin-bottom: 1rem
     display: grid
     row-gap: 1rem
-    border: 1px solid $medgrey
     .subtitle
       font-size: 1.25rem
       font-weight: 700

--- a/app/src/views/search/SearchOptions.vue
+++ b/app/src/views/search/SearchOptions.vue
@@ -341,9 +341,9 @@ ModalKetcher(
 @use '@/styles/transition' as *
 @use '@/styles/tabs' as *
 .search-options
-  max-height: 900vh
+  max-height: 90vh
   .options-title
-    font-size: 1 rem
+    font-size: 1rem
     font-family: 'Roboto', Helvetica, Arial, sans-serif
     font-weight: 500
     cursor: pointer
@@ -351,7 +351,7 @@ ModalKetcher(
     border-radius: 0.25rem
     margin-top: 1rem
     color: white
-    background-color: $linkblue
+    background-color: $color-primary
     display: flex
     align-content: center
     justify-content: space-between

--- a/app/src/views/search/SearchResults.vue
+++ b/app/src/views/search/SearchResults.vue
@@ -128,7 +128,7 @@ export default {
       transition: 0.25s
       border: 4px solid white
       &:hover
-        box-shadow: 0 0 5px $darkgrey
+        box-shadow: 0 0 5px $color-shadow-2
       .select
         input, label
           cursor: pointer
@@ -170,7 +170,7 @@ export default {
       background-color: $color-primary
       border-radius: 0.25rem
       cursor: pointer
-      box-shadow: 0 0 5px $darkgrey
+      box-shadow: 0 0 5px $color-shadow-2
       animation: bounce 5s infinite ease-in-out
       @keyframes bounce
         0%, 20%

--- a/app/src/views/search/SearchResults.vue
+++ b/app/src/views/search/SearchResults.vue
@@ -159,7 +159,7 @@ export default {
             overflow: hidden
             text-overflow: ellipsis
       &.selected
-        border-color: $linkblue
+        border-color: $color-primary
   .view-selected-container
     position: fixed
     bottom: 2rem
@@ -167,7 +167,7 @@ export default {
     .view-selected-button
       padding: 0.5rem 1rem
       color: white
-      background-color: $linkblue
+      background-color: $color-primary
       border-radius: 0.25rem
       cursor: pointer
       box-shadow: 0 0 5px $darkgrey


### PR DESCRIPTION
Picks up the UI updates from #171 (by @alli-linhart at Lucy-Family-Institute) onto current main and irons out a few rough spots so it can land here.

## Summary
- Cherry-picks the substantive commit from #171: grey borders, color palette, and fonts pulled from ord-app. About.vue border-top toggles, search-options sidebar restyle, plus a large set of new `$color-*` / `$gray-*` / `$dark-*` style variables in `vars.sass`.
- Fixes two CSS typos that slipped into the original commit: `1 rem` → `1rem` and `900vh` → `90vh` in `SearchOptions.vue`.
- Consolidates style variables: drops the duplicate `$lightgrey` / `$medgrey` / `$linkblue` / `$hoverblue` aliases (the PR redefined them to mirror new `$color-*` values) and renames `$darkgrey` → `$color-shadow-2` so the codebase uses a single naming scheme.
- Drops the PR's `vue.config.js` proxy tweak — that file was removed in the Vite migration (#176), and `vite.config.js` deliberately uses `127.0.0.1:5000` (see in-file comment).

The proxy change aside, every other style/UI change from #171 is preserved. Color values are unchanged across the rename pass.

## Test plan
- [ ] `npm run format:check` (passes locally)
- [ ] `npm run lint` (passes; only pre-existing warnings)
- [ ] `npm run build` (passes locally)
- [ ] Visual: load Home, About, Browse, Search, Dataset, Reaction views in dev server and confirm the new palette / borders / fonts render as intended
- [ ] Visual: confirm the search-options sidebar is sized/styled correctly with the typo fixes