### PR TITLE
Add editor deactivation banner to login and datasets pages

### DIFF
--- a/ord_interface/editor/html/datasets.html
+++ b/ord_interface/editor/html/datasets.html
@@ -138,6 +138,20 @@ limitations under the License.
             </div>
         </div>
     </nav>
+    <div class="container mt-3">
+        <div class="alert alert-danger border-2" role="alert">
+            <h4 class="alert-heading mb-2">⚠️ Editor Deactivation Notice</h4>
+            <p class="mb-2">
+                The ORD editor will be <strong>deactivated after July 31, 2026</strong>.
+                Please download any datasets you wish to keep before that date using the
+                links in the list below.
+            </p>
+            <p class="mb-0">
+                Questions? Contact
+                <a href="mailto:help@open-reaction-database.org">help@open-reaction-database.org</a>.
+            </p>
+        </div>
+    </div>
     <div class="container">
         <div id="identity" class="float-end">
             <div style="display: flex;"><img src="{{ user_avatar }}" alt="">{{ user_name }}</div>

--- a/ord_interface/editor/html/datasets.html
+++ b/ord_interface/editor/html/datasets.html
@@ -146,6 +146,11 @@ limitations under the License.
                 Please download any datasets you wish to keep before that date using the
                 links in the list below.
             </p>
+            <p class="mb-2">
+                The new editor is available at
+                <a href="https://app.open-reaction-database.org/">https://app.open-reaction-database.org/</a>
+                (<a href="https://www.linkedin.com/pulse/next-generation-reaction-editor-here-open-reaction-database-tfste/">learn more</a>).
+            </p>
             <p class="mb-0">
                 Questions? Contact
                 <a href="mailto:help@open-reaction-database.org">help@open-reaction-database.org</a>.

--- a/ord_interface/editor/html/login.html
+++ b/ord_interface/editor/html/login.html
@@ -69,6 +69,9 @@ limitations under the License.
       <strong>Notice:</strong> The ORD editor will be deactivated after <strong>July 31, 2026</strong>.
       Please download any datasets you wish to keep before that date.
       <br>
+      The new editor is available at <a href="https://app.open-reaction-database.org/">https://app.open-reaction-database.org/</a>
+      (<a href="https://www.linkedin.com/pulse/next-generation-reaction-editor-here-open-reaction-database-tfste/">learn more</a>).
+      <br>
       Questions? Contact <a href="mailto:help@open-reaction-database.org">help@open-reaction-database.org</a>.
     </div>
     <div id="container">

--- a/ord_interface/editor/html/login.html
+++ b/ord_interface/editor/html/login.html
@@ -46,8 +46,31 @@ limitations under the License.
     #button:hover {
       border-color: black;
     }
+    #deactivation-banner {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      background-color: #f8d7da;
+      border-bottom: 2px solid #dc3545;
+      color: #842029;
+      padding: 16px 24px;
+      font-family: Roboto, sans-serif;
+      font-size: 14pt;
+      text-align: center;
+      z-index: 1000;
+    }
+    #deactivation-banner strong {
+      font-size: 16pt;
+    }
   </style>
   <body>
+    <div id="deactivation-banner">
+      <strong>Notice:</strong> The ORD editor will be deactivated after <strong>July 31, 2026</strong>.
+      Please download any datasets you wish to keep before that date.
+      <br>
+      Questions? Contact <a href="mailto:help@open-reaction-database.org">help@open-reaction-database.org</a>.
+    </div>
     <div id="container">
       <div id="button">
         <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png">


### PR DESCRIPTION
## Summary
- Adds a red deactivation notice to the legacy editor's login and datasets pages, warning that the editor will be deactivated after July 31, 2026.
- Tells users to download any datasets they want to keep before that date.
- Points users to the new editor at https://app.open-reaction-database.org/ and the [LinkedIn announcement](https://www.linkedin.com/pulse/next-generation-reaction-editor-here-open-reaction-database-tfste/) for more context.
- Points users at help@open-reaction-database.org for questions.

## Test plan
- [ ] Open `ord_interface/editor/html/login.html` and confirm the red banner is pinned to the top with the deactivation date, download reminder, new-editor link with "learn more", and help email each on their own line.
- [ ] Open `ord_interface/editor/html/datasets.html` (or load `/datasets` in the editor) and confirm the Bootstrap `alert-danger` banner sits above the user identity strip, with the same three paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)