### PR TITLE
Pass datasetId into ChartView and guard its data fetch

### DIFF
--- a/app/src/views/dataset-view/ChartView.scss
+++ b/app/src/views/dataset-view/ChartView.scss
@@ -35,6 +35,17 @@
     transform: translate(-50%, -50%);
   }
 
+  &__error {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #b00;
+    font-size: 12px;
+    text-align: center;
+    padding: 0 12px;
+  }
+
   &__tooltip {
     position: fixed;
     background: white;

--- a/app/src/views/dataset-view/ChartView.tsx
+++ b/app/src/views/dataset-view/ChartView.tsx
@@ -197,14 +197,18 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, d
 
   // Fetch chart data when the endpoint or dataset changes. The resize effect
   // below redraws on isCollapsed change once inputsData is populated, so
-  // isCollapsed/createChart are intentionally not deps here.
+  // isCollapsed/createChart are intentionally not deps here. The
+  // AbortController guards against a stale response from the previous
+  // datasetId racing in after the new fetch has started.
   useEffect(() => {
+    const controller = new AbortController();
     setLoading(true);
     setFetchError(null);
-    fetch(`/api/${apiCall}?dataset_id=${encodeURIComponent(datasetId)}`, { method: 'GET' })
+    fetch(`/api/${apiCall}?dataset_id=${encodeURIComponent(datasetId)}`, {
+      method: 'GET',
+      signal: controller.signal,
+    })
       .then(response => {
-        // Throw on non-2xx so the catch branch surfaces the failure instead
-        // of feeding the HTML error body into setInputsData / createChart.
         if (!response.ok) {
           throw new Error(`${apiCall} failed (HTTP ${response.status})`);
         }
@@ -215,10 +219,12 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, d
         setInputsData(data);
       })
       .catch((error: Error) => {
+        if (error.name === 'AbortError') return;
         console.error(`Error fetching ${apiCall}:`, error);
         setLoading(false);
         setFetchError(error.message);
       });
+    return () => controller.abort();
   }, [apiCall, datasetId]);
 
   // Resize chart when isCollapsed changes

--- a/app/src/views/dataset-view/ChartView.tsx
+++ b/app/src/views/dataset-view/ChartView.tsx
@@ -201,7 +201,7 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, d
   useEffect(() => {
     setLoading(true);
     setFetchError(null);
-    fetch(`/api/${apiCall}?dataset_id=${datasetId}`, { method: 'GET' })
+    fetch(`/api/${apiCall}?dataset_id=${encodeURIComponent(datasetId)}`, { method: 'GET' })
       .then(response => {
         // Throw on non-2xx so the catch branch surfaces the failure instead
         // of feeding the HTML error body into setInputsData / createChart.

--- a/app/src/views/dataset-view/ChartView.tsx
+++ b/app/src/views/dataset-view/ChartView.tsx
@@ -36,6 +36,7 @@ interface ChartViewProps {
 
 const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, datasetId, isCollapsed = false }) => {
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [inputsData, setInputsData] = useState<ChartData[]>([]);
   const [showTooltip, setShowTooltip] = useState<'visible' | 'hidden'>('hidden');
   const [currentTimesAppearing, setCurrentTimesAppearing] = useState(0);
@@ -194,14 +195,16 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, d
     createChart(inputsData, width, height);
   }, [inputsData, isCollapsed, createChart]);
 
-  // Fetch data on mount. The resize effect below renders the chart once
-  // inputsData populates, so isCollapsed/createChart are intentionally not
-  // deps here — including them would re-fire the fetch every collapse toggle.
+  // Fetch chart data when the endpoint or dataset changes. The resize effect
+  // below redraws on isCollapsed change once inputsData is populated, so
+  // isCollapsed/createChart are intentionally not deps here.
   useEffect(() => {
+    setLoading(true);
+    setFetchError(null);
     fetch(`/api/${apiCall}?dataset_id=${datasetId}`, { method: 'GET' })
       .then(response => {
-        // Throw on non-2xx so the catch branch flips loading off instead of
-        // feeding the HTML error body into setInputsData / createChart.
+        // Throw on non-2xx so the catch branch surfaces the failure instead
+        // of feeding the HTML error body into setInputsData / createChart.
         if (!response.ok) {
           throw new Error(`${apiCall} failed (HTTP ${response.status})`);
         }
@@ -211,9 +214,10 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, d
         setLoading(false);
         setInputsData(data);
       })
-      .catch(error => {
+      .catch((error: Error) => {
         console.error(`Error fetching ${apiCall}:`, error);
         setLoading(false);
+        setFetchError(error.message);
       });
   }, [apiCall, datasetId]);
 
@@ -237,16 +241,20 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, d
         <svg
           ref={svgRef}
           id={uniqueId}
-          style={{ visibility: loading ? 'hidden' : 'visible' }}
+          style={{ visibility: loading || fetchError ? 'hidden' : 'visible' }}
         />
       </div>
 
-      <div
-        className="chart-view__loading"
-        style={{ visibility: loading ? 'visible' : 'hidden' }}
-      >
-        <LoadingSpinner />
-      </div>
+      {fetchError ? (
+        <div className="chart-view__error">Failed to load chart: {fetchError}</div>
+      ) : (
+        <div
+          className="chart-view__loading"
+          style={{ visibility: loading ? 'visible' : 'hidden' }}
+        >
+          <LoadingSpinner />
+        </div>
+      )}
 
       {showSmiles && (
         <div

--- a/app/src/views/dataset-view/ChartView.tsx
+++ b/app/src/views/dataset-view/ChartView.tsx
@@ -30,10 +30,11 @@ interface ChartViewProps {
   title: string;
   apiCall: string;
   role: string;
+  datasetId: string;
   isCollapsed?: boolean;
 }
 
-const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, isCollapsed = false }) => {
+const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, datasetId, isCollapsed = false }) => {
   const [loading, setLoading] = useState(true);
   const [inputsData, setInputsData] = useState<ChartData[]>([]);
   const [showTooltip, setShowTooltip] = useState<'visible' | 'hidden'>('hidden');
@@ -197,18 +198,24 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, i
   // inputsData populates, so isCollapsed/createChart are intentionally not
   // deps here — including them would re-fire the fetch every collapse toggle.
   useEffect(() => {
-    const datasetId = window.location.pathname.split('/')[2];
-
     fetch(`/api/${apiCall}?dataset_id=${datasetId}`, { method: 'GET' })
-      .then(response => response.json())
+      .then(response => {
+        // Throw on non-2xx so the catch branch flips loading off instead of
+        // feeding the HTML error body into setInputsData / createChart.
+        if (!response.ok) {
+          throw new Error(`${apiCall} failed (HTTP ${response.status})`);
+        }
+        return response.json();
+      })
       .then((data: ChartData[]) => {
         setLoading(false);
         setInputsData(data);
       })
-      .catch(() => {
+      .catch(error => {
+        console.error(`Error fetching ${apiCall}:`, error);
         setLoading(false);
       });
-  }, [apiCall]);
+  }, [apiCall, datasetId]);
 
   // Resize chart when isCollapsed changes
   useEffect(() => {

--- a/app/src/views/dataset-view/MainDatasetView.tsx
+++ b/app/src/views/dataset-view/MainDatasetView.tsx
@@ -76,20 +76,26 @@ const MainDatasetView: React.FC = () => {
             id="chartsectioncharts"
             className={`charts-content ${isCollapsed ? '' : 'expanded'}`}
           >
-            <ChartView
-              uniqueId="reactantsFrequency"
-              title="Frequency of Reactants"
-              apiCall="input_stats"
-              role="reactant"
-              isCollapsed={isCollapsed}
-            />
-            <ChartView
-              uniqueId="productsFrequency"
-              title="Frequency of Products"
-              apiCall="product_stats"
-              role="product"
-              isCollapsed={isCollapsed}
-            />
+            {datasetId && (
+              <>
+                <ChartView
+                  uniqueId="reactantsFrequency"
+                  title="Frequency of Reactants"
+                  apiCall="input_stats"
+                  role="reactant"
+                  datasetId={datasetId}
+                  isCollapsed={isCollapsed}
+                />
+                <ChartView
+                  uniqueId="productsFrequency"
+                  title="Frequency of Products"
+                  apiCall="product_stats"
+                  role="product"
+                  datasetId={datasetId}
+                  isCollapsed={isCollapsed}
+                />
+              </>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Closes #181, closes #182.

## Summary

- ChartView no longer reads `window.location.pathname` directly — it receives `datasetId` as a prop from `MainDatasetView`, which already has the id via `useParams()`. The charts only mount when the param is known so the prop is always a real string.
- The `/api/${apiCall}` data-fetch effect now gates on `response.ok`, throwing on non-2xx so the existing `.catch` branch flips the loading spinner off and logs, rather than feeding an HTML error body to `response.json()` and on into `setInputsData` / `createChart`.

## Test plan

- [ ] `cd app && npm run dev` plus the test backend (`ORD_INTERFACE_TESTING=TRUE uv run uvicorn ord_interface.api.main:app --port 5000 --reload`); open `/dataset/<id>` and confirm both Frequency charts render against the bundled test dataset.
- [ ] Temporarily point `apiCall` at a missing endpoint (or stop the backend) and confirm the spinner clears and an error is logged instead of a JSON parse blowing up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related bugs: `ChartView` was reading `window.location.pathname` directly to derive the dataset ID instead of receiving it as a prop, and the fetch effect would silently feed HTML error bodies into `response.json()` on non-2xx responses. Both are now corrected with a cleaner prop-passing pattern and a proper `response.ok` guard.

- `ChartView` now receives `datasetId` from `MainDatasetView` (which already has it via `useParams()`), `ChartViews` only mount when the id is known, and the fetch URL uses `encodeURIComponent` consistently with the metadata fetch in the same file.
- A new `AbortController` in the fetch effect cancels in-flight requests when the dataset changes, preventing stale responses from overwriting data for the new dataset.
- On non-2xx responses, an `Error` is thrown so the `.catch` branch sets `fetchError` and clears the spinner, and a styled `chart-view__error` element is shown instead of silently feeding bad JSON to the chart.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are narrowly scoped to how ChartView obtains its dataset ID and how fetch errors are handled, and both code paths are straightforward.

The prop-drilling replacement for the window.location.pathname hack is clean and correct. The response.ok guard, AbortController cleanup, and error UI are all implemented properly. The two previously flagged issues (encodeURIComponent and stale-fetch race) have been addressed in prior commits. No new defects were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/src/views/dataset-view/ChartView.tsx | Adds datasetId prop (replacing window.location.pathname parsing), AbortController for in-flight cancellation, response.ok guard before JSON parsing, and a fetchError state that renders an error message instead of a stale spinner. |
| app/src/views/dataset-view/MainDatasetView.tsx | Guards ChartView rendering behind a {datasetId &&} check and threads the datasetId prop down; no logic changes elsewhere. |
| app/src/views/dataset-view/ChartView.scss | Adds chart-view__error style (centred, dark-red, 12 px) to complement the new fetchError UI branch. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into chartview-route..."](https://github.com/open-reaction-database/ord-interface/commit/05c8945cf49cda2f5997dfbcb6b63c20bf786388) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33617662)</sub>

<!-- /greptile_comment -->