### PR TITLE
Bump idna 3.13 -> 3.17 to fix CVE-2026-45409

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -675,11 +675,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#65](https://github.com/open-reaction-database/ord-interface/security/dependabot/65) (GHSA-65pc-fj4g-8rjx / CVE-2026-45409).

`idna` (a transitive runtime dependency pinned in `uv.lock`) has a medium-severity DoS: specially crafted inputs to `idna.encode()` (e.g. `"٠" * N`) bypass the incomplete CVE-2024-3651 fix and consume significant CPU for large `N` (CWE-1333). Patched in idna 3.15.

This bumps the transitive pin `idna 3.13 -> 3.17` via `uv lock --upgrade-package idna`. Only `uv.lock` changes; no direct dependency or source code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)