### PR TITLE
ci: set explicit Codecov slug for org-wide token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,8 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          # CODECOV_TOKEN is an org-wide token, so the repo slug must be explicit.
+          slug: open-reaction-database/ord-interface
           fail_ci_if_error: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot/')) }}
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

`CODECOV_TOKEN` was changed to an **org-wide** upload token. Unlike a per-repo upload token, an org token does not identify the target Codecov project, so uploads depend on git-context slug detection. Set the slug explicitly to attribute coverage to this repo deterministically.

```diff
       - uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          # CODECOV_TOKEN is an org-wide token, so the repo slug must be explicit.
+          slug: open-reaction-database/ord-interface
           fail_ci_if_error: ${{ ... }}
           token: ${{ secrets.CODECOV_TOKEN }}
```

Part of a 3-repo set (ord-app, ord-schema, ord-interface) aligning Codecov uploads to the org-wide token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an explicit `slug: open-reaction-database/ord-interface` to the Codecov upload step in `tests.yml` to ensure coverage is attributed to the correct repository when using an org-wide `CODECOV_TOKEN`. The comment inline explains that org-wide tokens rely on git-context slug detection, which is not always reliable.

- Adds `slug` field to the `codecov/codecov-action@v5` step so uploads are deterministically routed to this repo's Codecov project rather than relying on auto-detection.
- Part of a coordinated change across three repositories (`ord-app`, `ord-schema`, `ord-interface`) aligning on the org-wide token strategy.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line addition correctly identifies the repository and has no effect on test execution or secrets handling.

The change adds a single, correctly valued slug field to the Codecov upload step. The slug matches the actual repository path, the token reference is unchanged, and no test or build logic is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/tests.yml | Added `slug: open-reaction-database/ord-interface` to the Codecov upload step; the value matches the actual repository name. No other logic is touched. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant CC as Codecov Action v5
    participant CCS as Codecov Service

    GHA->>CC: Upload coverage.xml
    Note over CC: slug: open-reaction-database/ord-interface
    Note over CC: token: CODECOV_TOKEN (org-wide)
    CC->>CCS: "POST /upload?slug=open-reaction-database/ord-interface"
    CCS-->>CC: Coverage attributed to correct repo
    CC-->>GHA: Upload success
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: set explicit Codecov slug for org-wi..."](https://github.com/open-reaction-database/ord-interface/commit/3314ff1b028a690271a9e25e60383bb5370bd9c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35037035)</sub>

<!-- /greptile_comment -->