### PR TITLE
Deduplicate stats queries and return proper HTTP errors

### DIFF
--- a/ord_interface/api/queries.py
+++ b/ord_interface/api/queries.py
@@ -50,7 +50,7 @@ from typing import Any
 from ord_schema import message_helpers, validations
 from ord_schema.logging import get_logger
 from ord_schema.proto import reaction_pb2
-from psycopg import AsyncCursor
+from psycopg import AsyncCursor, sql
 from pydantic import BaseModel
 from rdkit import Chem
 from rdkit.Chem import rdChemReactions
@@ -435,15 +435,38 @@ class StatsResult(BaseModel):
     times_appearing: int
 
 
-async def fetch_dataset_most_used_smiles_for_inputs(
-    cursor: DictCursor, dataset_id: str, limit: int = 30
+async def _fetch_dataset_most_used_smiles(
+    cursor: DictCursor,
+    dataset_id: str,
+    *,
+    compound_table: str,
+    join_table: str,
+    foreign_key: str,
+    limit: int,
 ) -> list[StatsResult]:
-    """Fetches the top K most used SMILES molecules in terms of reaction inputs for a given dataset."""
-    query = """
-            SELECT smiles, COUNT(*) as times_appearing
-            FROM ord.compound
-            JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
-            JOIN ord.reaction ON ord.reaction_input.reaction_id = ord.reaction.id
+    """Fetches the top K most used SMILES for a dataset, joined through the given tables.
+
+    Args:
+        cursor: Database cursor.
+        dataset_id: Dataset to aggregate over.
+        compound_table: Table holding SMILES, e.g. "compound" or "product_compound".
+        join_table: Table linking compounds to reactions, e.g. "reaction_input".
+        foreign_key: Column on ``compound_table`` referencing ``join_table``.
+        limit: Maximum number of rows to return.
+
+    Returns:
+        Most frequently appearing SMILES, in descending order of frequency.
+    """
+    # Compose schema-qualified identifiers safely rather than interpolating raw
+    # strings into the SQL text.
+    compound = sql.Identifier("ord", compound_table)
+    join = sql.Identifier("ord", join_table)
+    query = sql.SQL(
+        """
+            SELECT smiles, COUNT(*) AS times_appearing
+            FROM {compound}
+            JOIN {join} ON {compound}.{foreign_key} = {join}.id
+            JOIN ord.reaction ON {join}.reaction_id = ord.reaction.id
             JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
             WHERE ord.dataset.dataset_id = %s
             AND smiles IS NOT NULL
@@ -451,31 +474,37 @@ async def fetch_dataset_most_used_smiles_for_inputs(
             ORDER BY times_appearing DESC
             LIMIT %s
         """
+    ).format(compound=compound, join=join, foreign_key=sql.Identifier(foreign_key))
     await cursor.execute(query, (dataset_id, limit))
     results = []
     async for row in cursor:
         results.append(StatsResult(**row))
     return results
+
+
+async def fetch_dataset_most_used_smiles_for_inputs(
+    cursor: DictCursor, dataset_id: str, limit: int = 30
+) -> list[StatsResult]:
+    """Fetches the top K most used SMILES molecules in terms of reaction inputs for a given dataset."""
+    return await _fetch_dataset_most_used_smiles(
+        cursor,
+        dataset_id,
+        compound_table="compound",
+        join_table="reaction_input",
+        foreign_key="reaction_input_id",
+        limit=limit,
+    )
 
 
 async def fetch_dataset_most_used_smiles_for_products(
     cursor: DictCursor, dataset_id: str, limit: int = 30
 ) -> list[StatsResult]:
     """Fetches the top K most used SMILES molecules in terms of reaction products for a given dataset."""
-    query = """
-            SELECT smiles, COUNT(*) as times_appearing
-            FROM ord.product_compound
-            JOIN ord.reaction_outcome ON ord.product_compound.reaction_outcome_id = ord.reaction_outcome.id
-            JOIN ord.reaction ON ord.reaction_outcome.reaction_id = ord.reaction.id
-            JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
-            WHERE ord.dataset.dataset_id = %s
-            AND smiles IS NOT NULL
-            GROUP BY smiles
-            ORDER BY times_appearing DESC
-            LIMIT %s
-        """
-    await cursor.execute(query, (dataset_id, limit))
-    results = []
-    async for row in cursor:
-        results.append(StatsResult(**row))
-    return results
+    return await _fetch_dataset_most_used_smiles(
+        cursor,
+        dataset_id,
+        compound_table="product_compound",
+        join_table="reaction_outcome",
+        foreign_key="reaction_outcome_id",
+        limit=limit,
+    )

--- a/ord_interface/api/search.py
+++ b/ord_interface/api/search.py
@@ -224,7 +224,7 @@ async def get_molfile(smiles: str) -> str:
     """Returns a molblock for the given SMILES."""
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
-        raise ValueError(smiles)
+        raise HTTPException(status_code=400, detail=f"invalid SMILES: {smiles}")
     return Chem.MolToMolBlock(mol)
 
 

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -98,6 +98,11 @@ def test_get_molfile(test_client):
     assert Chem.MolToSmiles(Chem.MolFromMolBlock(response.json())) == "NC=O"
 
 
+def test_get_molfile_invalid_smiles(test_client):
+    response = test_client.get("/api/molfile", params={"smiles": "not-a-smiles"})
+    assert response.status_code == 400
+
+
 def test_get_search_results(test_client):
     response = test_client.post(
         "/api/download_search_results", json={"reaction_ids": ["ord-3f67aa5592fd434d97a577988d3fd241"]}

--- a/ord_interface/api/view.py
+++ b/ord_interface/api/view.py
@@ -14,7 +14,7 @@
 
 """View API."""
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from ord_schema.proto import reaction_pb2
 
@@ -39,8 +39,10 @@ async def get_compound(request: Request) -> str:
 async def get_reaction_summary(reaction_id: str, compact: bool = True) -> str:
     """Renders a reaction as an HTML table with images and text."""
     results = await get_reactions(ReactionIdList(reaction_ids=[reaction_id]))
-    if len(results) == 0 or len(results) > 1:
-        raise ValueError(reaction_id)
+    if len(results) == 0:
+        raise HTTPException(status_code=404, detail=f"reaction not found: {reaction_id}")
+    if len(results) > 1:
+        raise HTTPException(status_code=500, detail=f"multiple reactions found: {reaction_id}")
     try:
         return generate_text.generate_html(reaction=results[0].reaction, compact=compact)
     except (ValueError, KeyError):

--- a/ord_interface/api/view_test.py
+++ b/ord_interface/api/view_test.py
@@ -27,3 +27,8 @@ def test_get_compound_svg(test_client):
 def test_get_reaction_summary(test_client):
     response = test_client.get("/api/reaction_summary", params={"reaction_id": "ord-3f67aa5592fd434d97a577988d3fd241"})
     response.raise_for_status()
+
+
+def test_get_reaction_summary_not_found(test_client):
+    response = test_client.get("/api/reaction_summary", params={"reaction_id": "ord-does-not-exist"})
+    assert response.status_code == 404


### PR DESCRIPTION
Backend API consistency cleanup (Tier 2). No change to successful responses.

## Changes
- **Deduplicate the dataset stats queries.** `fetch_dataset_most_used_smiles_for_inputs` and `..._for_products` were identical apart from three table/column names. They now delegate to one private helper, with the differing identifiers composed via `psycopg.sql.Identifier` (schema-qualified, injection-safe) instead of duplicated query text. Public function signatures are unchanged.
- **Return meaningful HTTP errors instead of bare `ValueError`s** (which surface as opaque 500s):
  - `/molfile` with an unparseable SMILES → `400`
  - `/reaction_summary` for an unknown `reaction_id` → `404` (and `500` reserved for the genuinely-impossible "multiple matches" case)
- **Regression tests** for both new error paths.

## Deliberately deferred
The frontend fetch-error consolidation (also in the Tier 2 plan) touches `ChartView.tsx` and `MainDatasetView.tsx`, which are actively being edited on another branch — folding it in now would create merge conflicts, so it'll come separately.

## Testing
- `ruff check` / `ruff format --check`: clean
- `ty check ord_interface`: clean
- `pytest ord_interface/api` (with conda postgres): 54 passing, including the 2 new error-case tests and the existing stats tests that cover the refactored helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleans up backend API consistency by deduplicating two identical stats SQL queries into a shared private helper and replacing bare `ValueError` raises with proper FastAPI `HTTPException` responses.

- `_fetch_dataset_most_used_smiles` in `queries.py` composes schema-qualified table and column identifiers via `psycopg.sql.Identifier`, correctly mirroring both original queries; the `{compound}.{foreign_key}` three-part reference is valid PostgreSQL.
- `/molfile` with an unparseable SMILES now returns HTTP 400; `/reaction_summary` with an unknown ID returns 404, and the previously-combined guard for the impossible multi-match case is split into its own 500.
- Regression tests cover both new error paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are narrowly scoped, public function signatures are unchanged, and the refactored SQL has been validated against the two original queries it replaces.

The SQL refactoring correctly reconstructs both original queries using psycopg.sql.Identifier for all dynamic identifiers, the three-part schema.table.column reference is valid PostgreSQL, and the error-handling changes are straightforward substitutions of ValueError with typed HTTPExceptions. Regression tests confirm the new error paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_interface/api/queries.py | Deduplicates two identical SQL queries into a private helper using psycopg sql.Identifier for injection-safe table/column composition; logic is correct and mirrors original queries exactly. |
| ord_interface/api/search.py | Replaces bare ValueError with HTTPException(400) for invalid SMILES input; straightforward improvement consistent with existing 404 pattern in the same file. |
| ord_interface/api/view.py | Splits the original combined zero-or-many guard into separate 404 (not found) and 500 (impossible multiple-match) cases with descriptive detail messages. |
| ord_interface/api/search_test.py | Adds regression test for the new 400 path in /molfile with an invalid SMILES string. |
| ord_interface/api/view_test.py | Adds regression test for the new 404 path in /reaction_summary with an unknown reaction ID. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Deduplicate stats queries and return pro..."](https://github.com/open-reaction-database/ord-interface/commit/f0458289ec8a1b594659d5291c3eac0f0a4134c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37450553)</sub>

<!-- /greptile_comment -->