### PR TITLE
Adopt 88-char line length for Python and JS/TS

### DIFF
--- a/app/.prettierrc.json
+++ b/app/.prettierrc.json
@@ -1,6 +1,6 @@
 {
   "tabWidth": 2,
-  "printWidth": 120,
+  "printWidth": 88,
   "semi": true,
   "trailingComma": "all",
   "singleQuote": true,

--- a/app/index.html
+++ b/app/index.html
@@ -81,8 +81,8 @@
   <body>
     <noscript>
       <strong
-        >We're sorry but the Open Reaction Database doesn't work properly without JavaScript enabled. Please enable it
-        to continue.</strong
+        >We're sorry but the Open Reaction Database doesn't work properly without
+        JavaScript enabled. Please enable it to continue.</strong
       >
     </noscript>
     <div id="root"></div>

--- a/app/src/components/CopyButton.tsx
+++ b/app/src/components/CopyButton.tsx
@@ -23,7 +23,11 @@ interface CopyButtonProps {
   buttonText?: string;
 }
 
-const CopyButton: React.FC<CopyButtonProps> = ({ textToCopy, icon = 'content_copy', buttonText = '' }) => {
+const CopyButton: React.FC<CopyButtonProps> = ({
+  textToCopy,
+  icon = 'content_copy',
+  buttonText = '',
+}) => {
   const [displayNotification, setDisplayNotification] = useState(false);
   const [notificationStyle, setNotificationStyle] = useState({
     top: 0,

--- a/app/src/components/DownloadResults.tsx
+++ b/app/src/components/DownloadResults.tsx
@@ -74,7 +74,9 @@ const DownloadResults: React.FC<DownloadResultsProps> = ({
         onCloseModal={onHideDownloadResults}
       >
         <div className="download-body">
-          <div className="title">Select your desired file type and then click download.</div>
+          <div className="title">
+            Select your desired file type and then click download.
+          </div>
           <div className="options">
             <label htmlFor="file-type-select">File type:</label>
             <select

--- a/app/src/components/EntityTable.tsx
+++ b/app/src/components/EntityTable.tsx
@@ -24,7 +24,12 @@ interface EntityTableProps<T> {
   children: (entities: T[]) => ReactNode;
 }
 
-function EntityTable<T>({ tableData, title = '', displaySearch = true, children }: EntityTableProps<T>) {
+function EntityTable<T>({
+  tableData,
+  title = '',
+  displaySearch = true,
+  children,
+}: EntityTableProps<T>) {
   const [entities, setEntities] = useState<T[]>([]);
   const [searchString, setSearchString] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
@@ -111,7 +116,9 @@ function EntityTable<T>({ tableData, title = '', displaySearch = true, children 
     <div className="table-main">
       <div className="table-container">
         <div className="header">
-          <div className="title-holder">{title && <div className="title">{title}</div>}</div>
+          <div className="title-holder">
+            {title && <div className="title">{title}</div>}
+          </div>
         </div>
 
         {displaySearch && (
@@ -180,7 +187,9 @@ function EntityTable<T>({ tableData, title = '', displaySearch = true, children 
                 className={`paginav ${currentPage > 1 ? '' : 'no-click'}`}
                 onClick={() => currentPage > 1 && handlePageChange(currentPage - 1)}
               >
-                <span className="word">{currentPage > 1 ? currentPage - 1 : '...'}</span>
+                <span className="word">
+                  {currentPage > 1 ? currentPage - 1 : '...'}
+                </span>
               </div>
 
               <div className="paginav no-click">
@@ -189,9 +198,13 @@ function EntityTable<T>({ tableData, title = '', displaySearch = true, children 
 
               <div
                 className={`paginav ${currentPage < lastPage ? '' : 'no-click'}`}
-                onClick={() => currentPage < lastPage && handlePageChange(currentPage + 1)}
+                onClick={() =>
+                  currentPage < lastPage && handlePageChange(currentPage + 1)
+                }
               >
-                <span className="word">{currentPage < lastPage ? currentPage + 1 : '...'}</span>
+                <span className="word">
+                  {currentPage < lastPage ? currentPage + 1 : '...'}
+                </span>
               </div>
 
               <div

--- a/app/src/components/FloatingModal.tsx
+++ b/app/src/components/FloatingModal.tsx
@@ -23,7 +23,11 @@ interface FloatingModalProps {
   onCloseModal: () => void;
 }
 
-const FloatingModal: React.FC<FloatingModalProps> = ({ title, children, onCloseModal }) => {
+const FloatingModal: React.FC<FloatingModalProps> = ({
+  title,
+  children,
+  onCloseModal,
+}) => {
   return (
     <div className="modal-main">
       <div

--- a/app/src/components/ModalKetcher.tsx
+++ b/app/src/components/ModalKetcher.tsx
@@ -34,7 +34,11 @@ interface KetcherWindow extends Window {
   ketcher?: KetcherApi;
 }
 
-const ModalKetcher: React.FC<ModalKetcherProps> = ({ smiles, onUpdateSmiles, onCloseModal }) => {
+const ModalKetcher: React.FC<ModalKetcherProps> = ({
+  smiles,
+  onUpdateSmiles,
+  onCloseModal,
+}) => {
   const [contWin, setContWin] = useState<KetcherWindow | null>(null);
   const [mutatedSmiles, setMutatedSmiles] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
@@ -42,7 +46,9 @@ const ModalKetcher: React.FC<ModalKetcherProps> = ({ smiles, onUpdateSmiles, onC
   const drawSmiles = useCallback(async () => {
     if (mutatedSmiles && contWin?.ketcher) {
       try {
-        const response = await fetch(`/api/molfile?smiles=${encodeURIComponent(mutatedSmiles)}`);
+        const response = await fetch(
+          `/api/molfile?smiles=${encodeURIComponent(mutatedSmiles)}`,
+        );
         if (response.ok) {
           const molfile = (await response.json()) as string;
           contWin.ketcher.setMolecule(molfile);
@@ -95,7 +101,9 @@ const ModalKetcher: React.FC<ModalKetcherProps> = ({ smiles, onUpdateSmiles, onC
   // useCallback-based version re-fired on every relevant state change).
   useEffect(() => {
     const intervalId = window.setInterval(() => {
-      const iframe = document.getElementById('ketcher-iframe') as HTMLIFrameElement | null;
+      const iframe = document.getElementById(
+        'ketcher-iframe',
+      ) as HTMLIFrameElement | null;
       if (!iframe?.contentWindow) return;
       try {
         const win = iframe.contentWindow as KetcherWindow;

--- a/app/src/components/ReactionCard.tsx
+++ b/app/src/components/ReactionCard.tsx
@@ -17,7 +17,10 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import reaction_pb from 'ord-schema';
-import type { CompoundIdentifier, ProductMeasurement } from 'ord-schema/proto/reaction_pb';
+import type {
+  CompoundIdentifier,
+  ProductMeasurement,
+} from 'ord-schema/proto/reaction_pb';
 import LoadingSpinner from './LoadingSpinner';
 import CopyButton from './CopyButton';
 import { enumName } from '../utils/enum';
@@ -32,7 +35,8 @@ interface ReactionCardProps {
   onSelectionChange?: (reactionId: string, isSelected: boolean) => void;
 }
 
-const YIELD_MEASUREMENT_TYPE = reaction_pb.ProductMeasurement.ProductMeasurementType.YIELD;
+const YIELD_MEASUREMENT_TYPE =
+  reaction_pb.ProductMeasurement.ProductMeasurementType.YIELD;
 
 const ReactionCard: React.FC<ReactionCardProps> = ({
   reaction,
@@ -45,11 +49,15 @@ const ReactionCard: React.FC<ReactionCardProps> = ({
 
   const getReactionTable = useCallback(async () => {
     try {
-      const response = await fetch(`/api/reaction_summary?reaction_id=${reaction.reaction_id}`);
+      const response = await fetch(
+        `/api/reaction_summary?reaction_id=${reaction.reaction_id}`,
+      );
       // Skip the 4xx/5xx body — it's an HTML error page that
       // dangerouslySetInnerHTML would render verbatim in every card.
       if (!response.ok) {
-        console.error(`reaction_summary failed (HTTP ${response.status}) for ${reaction.reaction_id}`);
+        console.error(
+          `reaction_summary failed (HTTP ${response.status}) for ${reaction.reaction_id}`,
+        );
         return;
       }
       setReactionTable(await response.text());
@@ -82,20 +90,27 @@ const ReactionCard: React.FC<ReactionCardProps> = ({
     const pressure = data.conditions?.pressure?.setpoint;
     if (pressure) {
       const units = enumName(reaction_pb.Pressure.PressureUnit, pressure.units);
-      details.push(`under ${pressure.value}${units ? ` ${units.toLowerCase()}` : ' atm'}`);
+      details.push(
+        `under ${pressure.value}${units ? ` ${units.toLowerCase()}` : ' atm'}`,
+      );
     }
 
     const reactionTime = data.outcomesList?.[0]?.reactionTime;
     if (reactionTime?.value) {
       const units = enumName(reaction_pb.Time.TimeUnit, reactionTime.units);
-      details.push(`for ${reactionTime.value}${units ? ` ${units.toLowerCase()}` : 's'}`);
+      details.push(
+        `for ${reactionTime.value}${units ? ` ${units.toLowerCase()}` : 's'}`,
+      );
     }
 
     return details;
   };
 
   const productIdentifier = (identifier: CompoundIdentifier.AsObject): string => {
-    const type = enumName(reaction_pb.CompoundIdentifier.CompoundIdentifierType, identifier.type);
+    const type = enumName(
+      reaction_pb.CompoundIdentifier.CompoundIdentifierType,
+      identifier.type,
+    );
     return `${type ?? ''}: ${identifier.value}`;
   };
 
@@ -142,7 +157,11 @@ const ReactionCard: React.FC<ReactionCardProps> = ({
         )}
 
         <div className="reaction-table">
-          {reactionTable ? <div dangerouslySetInnerHTML={{ __html: reactionTable }} /> : <LoadingSpinner />}
+          {reactionTable ? (
+            <div dangerouslySetInnerHTML={{ __html: reactionTable }} />
+          ) : (
+            <LoadingSpinner />
+          )}
         </div>
 
         <div className="info">
@@ -151,15 +170,20 @@ const ReactionCard: React.FC<ReactionCardProps> = ({
           </div>
 
           <div className="col">
-            <div className="yield">Yield: {getYield(firstProduct?.measurementsList || [])}</div>
+            <div className="yield">
+              Yield: {getYield(firstProduct?.measurementsList || [])}
+            </div>
             <div className="conversion">Conversion: {getConversion(reactionData)}</div>
             <div className="conditions">
-              Conditions: {conditionsAndDuration(reactionData).join('; ') || 'Not Listed'}
+              Conditions:{' '}
+              {conditionsAndDuration(reactionData).join('; ') || 'Not Listed'}
             </div>
             {firstProductIdentifier && (
               <div className="smile">
                 <CopyButton textToCopy={firstProductIdentifier.value || ''} />
-                <div className="value">Product {productIdentifier(firstProductIdentifier)}</div>
+                <div className="value">
+                  Product {productIdentifier(firstProductIdentifier)}
+                </div>
               </div>
             )}
           </div>

--- a/app/src/hooks/useSearchTask.ts
+++ b/app/src/hooks/useSearchTask.ts
@@ -23,7 +23,9 @@ import type { SearchResult } from '../types/search';
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 120_000;
 
-type TaskState = { status: 'success'; results: SearchResult[] } | { status: 'pending'; taskId: string };
+type TaskState =
+  | { status: 'success'; results: SearchResult[] }
+  | { status: 'pending'; taskId: string };
 
 interface TaskRef {
   queryString: string | null;
@@ -52,21 +54,32 @@ export function useSearchTask(queryString: string | null, enabled: boolean) {
   // <StrictMode> dev the effect was re-running after queryFn had already set
   // startTime, leaving it at 0 — and "Date.now() - 0 > 120s" tripped the
   // timeout on the very first poll iteration.
-  const taskRef = useRef<TaskRef>({ queryString: null, taskId: null, submitPromise: null, startTime: 0 });
+  const taskRef = useRef<TaskRef>({
+    queryString: null,
+    taskId: null,
+    submitPromise: null,
+    startTime: 0,
+  });
 
   return useQuery<TaskState>({
     queryKey: ['search-task', queryString],
     enabled: enabled && queryString !== null,
     retry: false,
     staleTime: Infinity,
-    refetchInterval: query => (query.state.data?.status === 'pending' ? POLL_INTERVAL_MS : false),
+    refetchInterval: query =>
+      query.state.data?.status === 'pending' ? POLL_INTERVAL_MS : false,
     refetchIntervalInBackground: false,
     queryFn: async (): Promise<TaskState> => {
       if (!queryString) return { status: 'success', results: [] };
 
       // queryString changed since the last call — start fresh.
       if (taskRef.current.queryString !== queryString) {
-        taskRef.current = { queryString, taskId: null, submitPromise: null, startTime: 0 };
+        taskRef.current = {
+          queryString,
+          taskId: null,
+          submitPromise: null,
+          startTime: 0,
+        };
       }
 
       if (taskRef.current.taskId === null) {
@@ -93,13 +106,17 @@ export function useSearchTask(queryString: string | null, enabled: boolean) {
         throw new Error(`Search task ${id} timed out after ${POLL_TIMEOUT_MS / 1000}s`);
       }
 
-      const res = await fetch(`/api/fetch_query_result?task_id=${taskRef.current.taskId}`);
+      const res = await fetch(
+        `/api/fetch_query_result?task_id=${taskRef.current.taskId}`,
+      );
 
       if (res.status === 200) {
         const raw = (await res.json()) as Omit<SearchResult, 'data'>[];
         const results: SearchResult[] = raw.map(r => ({
           ...r,
-          data: reaction_pb.Reaction.deserializeBinary(new Uint8Array(base64ToBytes(r.proto))).toObject(),
+          data: reaction_pb.Reaction.deserializeBinary(
+            new Uint8Array(base64ToBytes(r.proto)),
+          ).toObject(),
         }));
         taskRef.current.taskId = null;
         return { status: 'success', results };

--- a/app/src/utils/conditions.ts
+++ b/app/src/utils/conditions.ts
@@ -28,7 +28,10 @@ import type {
 import { enumName } from './enum';
 
 export const tempType = (type: number | undefined): string =>
-  enumName(reaction_pb.TemperatureConditions.TemperatureControl.TemperatureControlType, type) ?? '';
+  enumName(
+    reaction_pb.TemperatureConditions.TemperatureControl.TemperatureControlType,
+    type,
+  ) ?? '';
 
 export const tempSetPoint = (setpoint: Temperature.AsObject | undefined): string => {
   if (!setpoint) return 'None';
@@ -38,7 +41,8 @@ export const tempSetPoint = (setpoint: Temperature.AsObject | undefined): string
 };
 
 export const pressureType = (type: number | undefined): string =>
-  enumName(reaction_pb.PressureConditions.PressureControl.PressureControlType, type) ?? '';
+  enumName(reaction_pb.PressureConditions.PressureControl.PressureControlType, type) ??
+  '';
 
 export const pressureSetPoint = (setpoint: Pressure.AsObject | undefined): string => {
   if (!setpoint) return 'None';
@@ -47,8 +51,13 @@ export const pressureSetPoint = (setpoint: Pressure.AsObject | undefined): strin
   return `${setpoint.value}${precision} ${unit ? unit.toLowerCase() : ''}`;
 };
 
-export const pressureAtmo = (atmo: PressureConditions.Atmosphere.AsObject | undefined): string => {
-  const type = enumName(reaction_pb.PressureConditions.Atmosphere.AtmosphereType, atmo?.type);
+export const pressureAtmo = (
+  atmo: PressureConditions.Atmosphere.AsObject | undefined,
+): string => {
+  const type = enumName(
+    reaction_pb.PressureConditions.Atmosphere.AtmosphereType,
+    atmo?.type,
+  );
   return `${type ?? ''}${atmo?.details ? `, ${atmo.details}` : ''}`;
 };
 
@@ -60,12 +69,20 @@ export const stirType = (type: number | undefined): string =>
  * to numeric enum values, so "Rate" always rendered as undefined. Take the
  * type field explicitly.
  */
-export const stirRate = (rate: StirringConditions.StirringRate.AsObject | undefined): string =>
-  enumName(reaction_pb.StirringConditions.StirringRate.StirringRateType, rate?.type) ?? '';
+export const stirRate = (
+  rate: StirringConditions.StirringRate.AsObject | undefined,
+): string =>
+  enumName(reaction_pb.StirringConditions.StirringRate.StirringRateType, rate?.type) ??
+  '';
 
-export const illumType = (illum: IlluminationConditions.AsObject | undefined): string => {
+export const illumType = (
+  illum: IlluminationConditions.AsObject | undefined,
+): string => {
   if (!illum) return '';
-  const type = enumName(reaction_pb.IlluminationConditions.IlluminationType, illum.type);
+  const type = enumName(
+    reaction_pb.IlluminationConditions.IlluminationType,
+    illum.type,
+  );
   return `${type ?? ''}${illum.details ? `: ${illum.details}` : ''}`;
 };
 
@@ -80,7 +97,9 @@ export const lengthStr = (length: Length.AsObject | undefined): string | undefin
   return `${length.value}${unit ? ` ${unit.toLowerCase()}` : ''}`;
 };
 
-export const electrochemType = (type: ElectrochemistryConditions.AsObject['type'] | undefined): string =>
+export const electrochemType = (
+  type: ElectrochemistryConditions.AsObject['type'] | undefined,
+): string =>
   enumName(reaction_pb.ElectrochemistryConditions.ElectrochemistryType, type) ?? '';
 
 export const flowType = (type: FlowConditions.AsObject['type'] | undefined): string =>

--- a/app/src/utils/enum.ts
+++ b/app/src/utils/enum.ts
@@ -22,8 +22,12 @@
  * rather than indexable records, so this helper takes `unknown` for the map and
  * narrows internally rather than asking callers to add unsafe casts.
  */
-export function enumName(enumMap: unknown, value: number | undefined): string | undefined {
-  if (value === undefined || enumMap === null || typeof enumMap !== 'object') return undefined;
+export function enumName(
+  enumMap: unknown,
+  value: number | undefined,
+): string | undefined {
+  if (value === undefined || enumMap === null || typeof enumMap !== 'object')
+    return undefined;
   for (const [key, mapped] of Object.entries(enumMap as Record<string, unknown>)) {
     if (mapped === value) return key;
   }

--- a/app/src/utils/outcomes.ts
+++ b/app/src/utils/outcomes.ts
@@ -36,13 +36,17 @@ export const formattedTime = (time: Time.AsObject | undefined): string | null =>
  * Used by both ReactionCard yield/conversion and OutcomesView so the two
  * call sites stay in sync.
  */
-export const formatPercentage = (percentage: Percentage.AsObject | undefined): string => {
+export const formatPercentage = (
+  percentage: Percentage.AsObject | undefined,
+): string => {
   if (!percentage) return '';
   const rounded = Math.round(percentage.value * 10) / 10;
   // Percentage.precision defaults to 0 in proto3; treat 0 as "no precision
   // recorded" rather than "± 0", matching the Vue OutcomesView's
   // `isNaN(precision)` guard.
   const precision =
-    Number.isFinite(percentage.precision) && percentage.precision !== 0 ? ` ± ${percentage.precision}` : '';
+    Number.isFinite(percentage.precision) && percentage.precision !== 0
+      ? ` ± ${percentage.precision}`
+      : '';
   return `${rounded}%${precision}`;
 };

--- a/app/src/views/About.tsx
+++ b/app/src/views/About.tsx
@@ -26,36 +26,44 @@ const About: React.FC = () => {
         </div>
         <div className="col-9 about__section-content">
           <p className="about__text">
-            The Open Reaction Database (ORD) is an open-access schema and infrastructure for structuring and sharing
-            organic reaction data, including a centralized data repository. The ORD schema supports conventional and
-            emerging technologies, from benchtop reactions to automated high-throughput experiments and flow chemistry.
-            Our vision is that a consistent data representation and infrastructure to support data sharing will enable
-            downstream applications that will greatly improve the state of the art with respect to computer-aided
-            synthesis planning, reaction prediction, and other predictive chemistry tasks.
+            The Open Reaction Database (ORD) is an open-access schema and infrastructure
+            for structuring and sharing organic reaction data, including a centralized
+            data repository. The ORD schema supports conventional and emerging
+            technologies, from benchtop reactions to automated high-throughput
+            experiments and flow chemistry. Our vision is that a consistent data
+            representation and infrastructure to support data sharing will enable
+            downstream applications that will greatly improve the state of the art with
+            respect to computer-aided synthesis planning, reaction prediction, and other
+            predictive chemistry tasks.
           </p>
           <p className="about__text">
-            Since our initial meeting in October 2019, the database has grown to include more than 2M reactions
-            (including a large dataset of reactions extracted from USPTO sources) and received contributions from
-            academic and industrial users, both from published and unpublished work. Some of our current efforts
+            Since our initial meeting in October 2019, the database has grown to include
+            more than 2M reactions (including a large dataset of reactions extracted
+            from USPTO sources) and received contributions from academic and industrial
+            users, both from published and unpublished work. Some of our current efforts
             include:
           </p>
           <ul className="about__list">
             <li className="about__list-item">
-              Improving user interfaces and providing support to contributors on GitHub and via email.
+              Improving user interfaces and providing support to contributors on GitHub
+              and via email.
             </li>
             <li className="about__list-item">
-              Working with companies to incorporate the ORD schema into their reaction informatics infrastructure,
-              including the development of "translators" between the ORD schema and electronic lab notebooks (ELNs).
+              Working with companies to incorporate the ORD schema into their reaction
+              informatics infrastructure, including the development of "translators"
+              between the ORD schema and electronic lab notebooks (ELNs).
             </li>
             <li className="about__list-item">
-              Engaging with journals and other stakeholders to drive adoption of the ORD schema as a{' '}
+              Engaging with journals and other stakeholders to drive adoption of the ORD
+              schema as a{' '}
               <a
                 href="https://en.wikipedia.org/wiki/FAIR_data"
                 className="about__link"
               >
                 FAIR
               </a>{' '}
-              data structure for sharing reaction data across academia, government, and industry.
+              data structure for sharing reaction data across academia, government, and
+              industry.
             </li>
           </ul>
           <p className="about__text">
@@ -65,14 +73,16 @@ const About: React.FC = () => {
             >
               Ben Deadman
             </a>{' '}
-            is our Reaction Data Evangelist and ORD Program Manager. Please reach out to him at{' '}
+            is our Reaction Data Evangelist and ORD Program Manager. Please reach out to
+            him at{' '}
             <a
               href="mailto:help@open-reaction-database.org"
               className="about__link"
             >
               help@open‑reaction‑database.org
             </a>{' '}
-            for help preparing a contribution or to discuss using the ORD in your company or lab.
+            for help preparing a contribution or to discuss using the ORD in your
+            company or lab.
           </p>
         </div>
       </div>
@@ -85,8 +95,9 @@ const About: React.FC = () => {
           <h5 className="about__subsection-title">Journal Articles</h5>
           <ul className="about__list">
             <li className="about__list-item">
-              Kearnes SM, Maser MR, Wleklinski M, Kast A, Doyle AG, Dreher SD, Hawkins JM, Jensen KF, Coley CW. The Open
-              Reaction Database. <em>J Am Chem Soc</em> 2021, 143(45), 18820-18826. (
+              Kearnes SM, Maser MR, Wleklinski M, Kast A, Doyle AG, Dreher SD, Hawkins
+              JM, Jensen KF, Coley CW. The Open Reaction Database.{' '}
+              <em>J Am Chem Soc</em> 2021, 143(45), 18820-18826. (
               <a
                 href="https://doi.org/10.1021/jacs.1c09820"
                 className="about__link"
@@ -96,8 +107,9 @@ const About: React.FC = () => {
               )
             </li>
             <li className="about__list-item">
-              Mercado R, Kearnes SM, Coley C. Data Sharing in Chemistry: Lessons Learned and a Case for Mandating
-              Structured Reaction Data. <em>J Chem Inf Model</em> 2023, 63(14), 4253-4265. (
+              Mercado R, Kearnes SM, Coley C. Data Sharing in Chemistry: Lessons Learned
+              and a Case for Mandating Structured Reaction Data.{' '}
+              <em>J Chem Inf Model</em> 2023, 63(14), 4253-4265. (
               <a
                 href="https://doi.org/10.1021/acs.jcim.3c00607"
                 className="about__link"
@@ -130,7 +142,8 @@ const About: React.FC = () => {
               , 12 May 2022)
             </li>
             <li className="about__list-item">
-              Chemists debate machine learning's future in synthesis planning and ask for open data (
+              Chemists debate machine learning's future in synthesis planning and ask
+              for open data (
               <a
                 href="https://cen.acs.org/physical-chemistry/computational-chemistry/Chemists-debate-machine-learnings-future/100/i18"
                 className="about__link"
@@ -176,7 +189,9 @@ const About: React.FC = () => {
             <ul className="about__leadership-column">
               <li className="about__list-item">Alán Aspuru-Guzik (Toronto, MADNESS)</li>
               <li className="about__list-item">Timothy Cernak (Michigan, Entos)</li>
-              <li className="about__list-item">Lucy Colwell (Cambridge, SynTech, Google)</li>
+              <li className="about__list-item">
+                Lucy Colwell (Cambridge, SynTech, Google)
+              </li>
               <li className="about__list-item">Werngard Czechtizky (AstraZeneca)</li>
               <li className="about__list-item">JW Feng</li>
               <li className="about__list-item">Matthew Gaunt (Cambridge, SynTech)</li>

--- a/app/src/views/browse/selected-set/MainSelectedSet.tsx
+++ b/app/src/views/browse/selected-set/MainSelectedSet.tsx
@@ -49,7 +49,9 @@ const MainSelectedSet: React.FC = () => {
 
       const decoded: SearchResult[] = fetched.map(r => ({
         ...r,
-        data: reaction_pb.Reaction.deserializeBinary(new Uint8Array(base64ToBytes(r.proto))).toObject(),
+        data: reaction_pb.Reaction.deserializeBinary(
+          new Uint8Array(base64ToBytes(r.proto)),
+        ).toObject(),
       }));
 
       setReactions(decoded);
@@ -86,7 +88,9 @@ const MainSelectedSet: React.FC = () => {
           <div className="title">Reaction Set</div>
         </div>
         <div className="no-results">
-          <div className="title">There was an issue fetching your selected reactions.</div>
+          <div className="title">
+            There was an issue fetching your selected reactions.
+          </div>
         </div>
       </div>
     );

--- a/app/src/views/dataset-view/ChartView.tsx
+++ b/app/src/views/dataset-view/ChartView.tsx
@@ -34,7 +34,14 @@ interface ChartViewProps {
   isCollapsed?: boolean;
 }
 
-const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, datasetId, isCollapsed = false }) => {
+const ChartView: React.FC<ChartViewProps> = ({
+  uniqueId,
+  title,
+  apiCall,
+  role,
+  datasetId,
+  isCollapsed = false,
+}) => {
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [inputsData, setInputsData] = useState<ChartData[]>([]);
@@ -126,7 +133,9 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, d
         .on('mouseover', (event: MouseEvent, d: ChartData) => {
           setCurrentTimesAppearing(d.times_appearing);
           setTooltipOffsetHorizontal(event.clientX);
-          setTooltipOffsetVertical(role === 'product' ? event.clientY - 240 : event.clientY - 140);
+          setTooltipOffsetVertical(
+            role === 'product' ? event.clientY - 240 : event.clientY - 140,
+          );
           setShowTooltip('visible');
           setShowSmiles(true);
           setMolLoading(true);
@@ -239,7 +248,9 @@ const ChartView: React.FC<ChartViewProps> = ({ uniqueId, title, apiCall, role, d
       <div className="chart-view__title-and-chart">
         <span
           className="chart-view__title"
-          style={isCollapsed ? { fontSize: '10pt', width: '150px' } : { fontSize: '14pt' }}
+          style={
+            isCollapsed ? { fontSize: '10pt', width: '150px' } : { fontSize: '14pt' }
+          }
         >
           {title}
         </span>

--- a/app/src/views/dataset-view/MainDatasetView.tsx
+++ b/app/src/views/dataset-view/MainDatasetView.tsx
@@ -29,7 +29,11 @@ const MainDatasetView: React.FC = () => {
   const [isCollapsed, setIsCollapsed] = useState(true);
 
   const datasetQuery = `?dataset_id=${datasetId}&limit=100`;
-  const { data: searchData, isFetching, error } = useSearchTask(datasetId ? datasetQuery : null, !!datasetId);
+  const {
+    data: searchData,
+    isFetching,
+    error,
+  } = useSearchTask(datasetId ? datasetQuery : null, !!datasetId);
   const searchResults = searchData?.status === 'success' ? searchData.results : [];
   const loading = !!datasetId && (isFetching || searchData?.status === 'pending');
 
@@ -37,7 +41,9 @@ const MainDatasetView: React.FC = () => {
     queryKey: ['dataset-metadata', datasetId],
     enabled: !!datasetId,
     queryFn: async () => {
-      const res = await fetch(`/api/dataset?dataset_id=${encodeURIComponent(datasetId!)}`);
+      const res = await fetch(
+        `/api/dataset?dataset_id=${encodeURIComponent(datasetId!)}`,
+      );
       if (!res.ok) {
         throw new Error(`Failed to load dataset metadata (HTTP ${res.status})`);
       }
@@ -67,7 +73,9 @@ const MainDatasetView: React.FC = () => {
                   className="material-icons"
                   title={isCollapsed ? 'Expand' : 'Collapse'}
                 >
-                  {isCollapsed ? 'keyboard_double_arrow_right' : 'keyboard_double_arrow_left'}
+                  {isCollapsed
+                    ? 'keyboard_double_arrow_right'
+                    : 'keyboard_double_arrow_left'}
                 </i>
               </button>
             </div>
@@ -103,7 +111,9 @@ const MainDatasetView: React.FC = () => {
           <div className="h4">Dataset Metadata</div>
           {datasetError ? (
             <div className="no-results">
-              <div className="title">Failed to load dataset metadata: {datasetError.message}</div>
+              <div className="title">
+                Failed to load dataset metadata: {datasetError.message}
+              </div>
             </div>
           ) : (
             <table>

--- a/app/src/views/reaction-view/CompoundView.tsx
+++ b/app/src/views/reaction-view/CompoundView.tsx
@@ -46,12 +46,20 @@ const CompoundView: React.FC<CompoundViewProps> = ({ component }) => {
   const [compoundSVG, setCompoundSVG] = useState<string | null>(null);
   const [showRawData, setShowRawData] = useState(false);
 
-  const compoundAmountObj = useMemo(() => amountObj(component?.amount), [component?.amount]);
-  const compoundAmount = useMemo(() => amountStr(compoundAmountObj), [compoundAmountObj]);
+  const compoundAmountObj = useMemo(
+    () => amountObj(component?.amount),
+    [component?.amount],
+  );
+  const compoundAmount = useMemo(
+    () => amountStr(compoundAmountObj),
+    [compoundAmountObj],
+  );
 
   const compoundRole = useMemo(() => {
     if (!component?.reactionRole) return '';
-    return String(enumName(reaction_pb.ReactionRole.ReactionRoleType, component.reactionRole) ?? '');
+    return String(
+      enumName(reaction_pb.ReactionRole.ReactionRoleType, component.reactionRole) ?? '',
+    );
   }, [component?.reactionRole]);
 
   const rawData: RawData = useMemo(() => {
@@ -59,7 +67,12 @@ const CompoundView: React.FC<CompoundViewProps> = ({ component }) => {
 
     if (component?.identifiersList?.length) {
       returnObj.identifiers = component.identifiersList.map(identifier => ({
-        type: String(enumName(reaction_pb.CompoundIdentifier.CompoundIdentifierType, identifier.type) ?? ''),
+        type: String(
+          enumName(
+            reaction_pb.CompoundIdentifier.CompoundIdentifierType,
+            identifier.type,
+          ) ?? '',
+        ),
         value: identifier.value,
       }));
     }
@@ -75,7 +88,12 @@ const CompoundView: React.FC<CompoundViewProps> = ({ component }) => {
 
     if (component?.preparationsList?.length) {
       returnObj.preparations = component.preparationsList.map(prep => ({
-        type: String(enumName(reaction_pb.CompoundPreparation.CompoundPreparationType, prep.type) ?? ''),
+        type: String(
+          enumName(
+            reaction_pb.CompoundPreparation.CompoundPreparationType,
+            prep.type,
+          ) ?? '',
+        ),
         details: prep.details,
       }));
     }
@@ -90,7 +108,8 @@ const CompoundView: React.FC<CompoundViewProps> = ({ component }) => {
 
     if (component?.texture) {
       const textureObj: { type: string; details?: string } = {
-        type: component.texture.type !== undefined ? String(component.texture.type) : '',
+        type:
+          component.texture.type !== undefined ? String(component.texture.type) : '',
       };
       if (component.texture.details) {
         textureObj.details = component.texture.details;
@@ -101,12 +120,17 @@ const CompoundView: React.FC<CompoundViewProps> = ({ component }) => {
     return returnObj;
   }, [component, compoundRole, compoundAmountObj]);
 
-  const gridColumns = useMemo(() => `1fr repeat(${component?.amount ? 3 : 2}, auto)`, [component?.amount]);
+  const gridColumns = useMemo(
+    () => `1fr repeat(${component?.amount ? 3 : 2}, auto)`,
+    [component?.amount],
+  );
 
   const smilesValue = useMemo(() => {
     if (!component?.identifiersList?.length) return null;
     const smilesType = reaction_pb.CompoundIdentifier.CompoundIdentifierType.SMILES;
-    const smilesIdentifier = component.identifiersList.find(identifier => identifier.type === smilesType);
+    const smilesIdentifier = component.identifiersList.find(
+      identifier => identifier.type === smilesType,
+    );
     return smilesIdentifier?.value ?? null;
   }, [component?.identifiersList]);
 
@@ -181,8 +205,12 @@ const CompoundView: React.FC<CompoundViewProps> = ({ component }) => {
             ))}
             {rawData.amount && <pre>amount: {JSON.stringify(rawData.amount)}</pre>}
             <pre>reaction_role: {rawData.reaction_role}</pre>
-            {rawData.is_desired_product && <pre>is_desired_product: {rawData.is_desired_product}</pre>}
-            {rawData.isolated_color && <pre>isolated_color: {rawData.isolated_color}</pre>}
+            {rawData.is_desired_product && (
+              <pre>is_desired_product: {rawData.is_desired_product}</pre>
+            )}
+            {rawData.isolated_color && (
+              <pre>isolated_color: {rawData.isolated_color}</pre>
+            )}
             {rawData.texture && <pre>texture: {JSON.stringify(rawData.texture)}</pre>}
             {rawData.preparations?.map((prep, index) => (
               <pre key={index}>preparations: {JSON.stringify(prep)}</pre>

--- a/app/src/views/reaction-view/MainReactionView.tsx
+++ b/app/src/views/reaction-view/MainReactionView.tsx
@@ -50,7 +50,15 @@ const MainReactionView: React.FC = () => {
   const [activeNav, setActiveNav] = useState<string>('summary');
 
   const setupTabs = ['vessel', 'environment', 'automation'];
-  const conditionTabs = ['temperature', 'pressure', 'stirring', 'illumination', 'electrochemistry', 'flow', 'other'];
+  const conditionTabs = [
+    'temperature',
+    'pressure',
+    'stirring',
+    'illumination',
+    'electrochemistry',
+    'flow',
+    'other',
+  ];
 
   const getReactionData = useCallback(async (): Promise<ReactionData | null> => {
     if (!reactionId) return null;
@@ -67,10 +75,14 @@ const MainReactionView: React.FC = () => {
       if (!data?.[0]?.proto) return null;
 
       const bytes = base64ToBytes(data[0].proto);
-      const decoded = reaction_pb.Reaction.deserializeBinary(new Uint8Array(bytes)).toObject();
+      const decoded = reaction_pb.Reaction.deserializeBinary(
+        new Uint8Array(bytes),
+      ).toObject();
 
       // Sort inputs by their declared addition order.
-      decoded.inputsMap?.sort((a, b) => (a[1].additionOrder ?? 0) - (b[1].additionOrder ?? 0));
+      decoded.inputsMap?.sort(
+        (a, b) => (a[1].additionOrder ?? 0) - (b[1].additionOrder ?? 0),
+      );
 
       return decoded;
     } catch (error) {
@@ -83,11 +95,15 @@ const MainReactionView: React.FC = () => {
     if (!reactionId) return '';
 
     try {
-      const response = await fetch(`/api/reaction_summary?reaction_id=${reactionId}&compact=false`);
+      const response = await fetch(
+        `/api/reaction_summary?reaction_id=${reactionId}&compact=false`,
+      );
       // Don't pipe a 4xx/5xx HTML error body into the summary panel via
       // dangerouslySetInnerHTML; return empty so the section stays blank.
       if (!response.ok) {
-        console.error(`reaction_summary failed (HTTP ${response.status}) for ${reactionId}`);
+        console.error(
+          `reaction_summary failed (HTTP ${response.status}) for ${reactionId}`,
+        );
         return '';
       }
       return await response.text();
@@ -120,8 +136,10 @@ const MainReactionView: React.FC = () => {
 
     if (input.additionSpeed?.type !== undefined) {
       formatted.additionSpeed =
-        enumName(reaction_pb.ReactionInput.AdditionSpeed.AdditionSpeedType, input.additionSpeed.type)?.toLowerCase() ??
-        '';
+        enumName(
+          reaction_pb.ReactionInput.AdditionSpeed.AdditionSpeedType,
+          input.additionSpeed.type,
+        )?.toLowerCase() ?? '';
     }
 
     if (input.additionDuration) {
@@ -134,7 +152,12 @@ const MainReactionView: React.FC = () => {
   const displayConditionsOther = useMemo(() => {
     const conditions = reaction?.conditions;
     if (!conditions) return undefined;
-    const otherFields: Array<keyof typeof conditions> = ['reflux', 'ph', 'conditionsAreDynamic', 'details'];
+    const otherFields: Array<keyof typeof conditions> = [
+      'reflux',
+      'ph',
+      'conditionsAreDynamic',
+      'details',
+    ];
     return otherFields.find(key => conditions[key]);
   }, [reaction?.conditions]);
 
@@ -142,7 +165,10 @@ const MainReactionView: React.FC = () => {
     const provenance = reaction?.provenance;
     if (!provenance?.recordCreated) return [];
 
-    const created: RecordEvent.AsObject = { ...provenance.recordCreated, details: '(record created)' };
+    const created: RecordEvent.AsObject = {
+      ...provenance.recordCreated,
+      details: '(record created)',
+    };
     const modified = provenance.recordModifiedList ?? [];
     const all = [created, ...modified];
 
@@ -171,7 +197,10 @@ const MainReactionView: React.FC = () => {
     const fetchData = async () => {
       if (!reactionId) return;
 
-      const [reactionData, summaryData] = await Promise.all([getReactionData(), getReactionSummary()]);
+      const [reactionData, summaryData] = await Promise.all([
+        getReactionData(),
+        getReactionSummary(),
+      ]);
 
       if (reactionData) {
         setReaction(reactionData);
@@ -311,12 +340,14 @@ const MainReactionView: React.FC = () => {
                   </div>
                   <div className="title">Components</div>
                   <div className="compound">
-                    {reaction.inputsMap[inputsIdx][1].componentsList?.map((component, index) => (
-                      <CompoundView
-                        key={index}
-                        component={component}
-                      />
-                    ))}
+                    {reaction.inputsMap[inputsIdx][1].componentsList?.map(
+                      (component, index) => (
+                        <CompoundView
+                          key={index}
+                          component={component}
+                        />
+                      ),
+                    )}
                   </div>
                 </div>
               </div>

--- a/app/src/views/reaction-view/OutcomesView.tsx
+++ b/app/src/views/reaction-view/OutcomesView.tsx
@@ -32,7 +32,8 @@ interface OutcomesViewProps {
 const measurementType = (type: number | undefined): string =>
   enumName(reaction_pb.ProductMeasurement.ProductMeasurementType, type) ?? '';
 
-const analysisType = (type: number | undefined): string => enumName(reaction_pb.Analysis.AnalysisType, type) ?? '';
+const analysisType = (type: number | undefined): string =>
+  enumName(reaction_pb.Analysis.AnalysisType, type) ?? '';
 
 const measurementValue = (measurement: ProductMeasurement.AsObject): string => {
   if (measurement.percentage) return formatPercentage(measurement.percentage);
@@ -55,8 +56,12 @@ const analysisWithNamedType = (analysis: Analysis.AsObject) => ({
 const OutcomesView: React.FC<OutcomesViewProps> = ({ outcome }) => {
   const [productsIdx, setProductsIdx] = useState(0);
   const [analysesIdx, setAnalysesIdx] = useState(0);
-  const [rawMeasurement, setRawMeasurement] = useState<ReturnType<typeof measurementWithNamedType> | null>(null);
-  const [rawAnalysis, setRawAnalysis] = useState<ReturnType<typeof analysisWithNamedType> | null>(null);
+  const [rawMeasurement, setRawMeasurement] = useState<ReturnType<
+    typeof measurementWithNamedType
+  > | null>(null);
+  const [rawAnalysis, setRawAnalysis] = useState<ReturnType<
+    typeof analysisWithNamedType
+  > | null>(null);
   const [customDetails, setCustomDetails] = useState<string | null>(null);
 
   if (!outcome) return null;
@@ -145,7 +150,9 @@ const OutcomesView: React.FC<OutcomesViewProps> = ({ outcome }) => {
                       <div className="raw">
                         <div
                           className="button"
-                          onClick={() => setRawMeasurement(measurementWithNamedType(measurement))}
+                          onClick={() =>
+                            setRawMeasurement(measurementWithNamedType(measurement))
+                          }
                         >
                           &lt;&gt;
                         </div>
@@ -207,7 +214,9 @@ const OutcomesView: React.FC<OutcomesViewProps> = ({ outcome }) => {
                   <div className="raw">
                     <div
                       className="button"
-                      onClick={() => setRawAnalysis(analysisWithNamedType(currentAnalysis))}
+                      onClick={() =>
+                        setRawAnalysis(analysisWithNamedType(currentAnalysis))
+                      }
                     >
                       &lt;&gt;
                     </div>

--- a/app/src/views/reaction-view/ProvenanceView.tsx
+++ b/app/src/views/reaction-view/ProvenanceView.tsx
@@ -54,7 +54,9 @@ const ProvenanceView: React.FC<ProvenanceViewProps> = ({ provenance }) => {
         {provenance?.experimentStart?.value && (
           <>
             <div className="label">Experiment Start</div>
-            <div className="value">{new Date(provenance.experimentStart.value).toLocaleDateString()}</div>
+            <div className="value">
+              {new Date(provenance.experimentStart.value).toLocaleDateString()}
+            </div>
           </>
         )}
 

--- a/app/src/views/reaction-view/SetupView.tsx
+++ b/app/src/views/reaction-view/SetupView.tsx
@@ -43,7 +43,10 @@ const SetupView: React.FC<SetupViewProps> = ({ setup, display }) => {
     if (!vessel?.attachmentsList?.length) return '';
     return vessel.attachmentsList
       .map(attach => {
-        const type = enumName(reaction_pb.VesselAttachment.VesselAttachmentType, attach.type);
+        const type = enumName(
+          reaction_pb.VesselAttachment.VesselAttachmentType,
+          attach.type,
+        );
         return `${String(type ?? '')}${attach.details ? `: ${attach.details}` : ''}`;
       })
       .join(', ');
@@ -53,7 +56,10 @@ const SetupView: React.FC<SetupViewProps> = ({ setup, display }) => {
     if (!vessel?.preparationsList?.length) return '';
     return vessel.preparationsList
       .map(prep => {
-        const type = enumName(reaction_pb.VesselPreparation.VesselPreparationType, prep.type);
+        const type = enumName(
+          reaction_pb.VesselPreparation.VesselPreparationType,
+          prep.type,
+        );
         return `${String(type ?? '')}${prep.details ? `: ${prep.details}` : ''}`;
       })
       .join(', ');
@@ -61,14 +67,22 @@ const SetupView: React.FC<SetupViewProps> = ({ setup, display }) => {
 
   const vesselMaterial = useMemo(() => {
     if (!vessel?.material?.type) return '';
-    return String(enumName(reaction_pb.VesselMaterial.VesselMaterialType, vessel.material.type) ?? '');
+    return String(
+      enumName(reaction_pb.VesselMaterial.VesselMaterialType, vessel.material.type) ??
+        '',
+    );
   }, [vessel?.material?.type]);
 
   const reactionEnv = useMemo(() => {
     const envVal = setup?.environment?.type;
     if (!envVal) return null;
     return (
-      String(enumName(reaction_pb.ReactionSetup.ReactionEnvironment.ReactionEnvironmentType, envVal) ?? '') || null
+      String(
+        enumName(
+          reaction_pb.ReactionSetup.ReactionEnvironment.ReactionEnvironmentType,
+          envVal,
+        ) ?? '',
+      ) || null
     );
   }, [setup?.environment?.type]);
 

--- a/app/src/views/reaction-view/WorkupsView.tsx
+++ b/app/src/views/reaction-view/WorkupsView.tsx
@@ -32,14 +32,17 @@ const NAME_IDENTIFIER_TYPE = reaction_pb.CompoundIdentifier.CompoundIdentifierTy
 const getNameIdentifier = (identifiers: CompoundIdentifier.AsObject[]): string => {
   // Falls back to the first identifier when the compound has no NAME entry,
   // rather than throwing the way the Vue source did.
-  const nameIdentifier = identifiers.find(identifier => identifier.type === NAME_IDENTIFIER_TYPE);
+  const nameIdentifier = identifiers.find(
+    identifier => identifier.type === NAME_IDENTIFIER_TYPE,
+  );
   return nameIdentifier?.value ?? identifiers[0]?.value ?? '';
 };
 
 const WorkupsView: React.FC<WorkupsViewProps> = ({ workup }) => {
   if (!workup) return null;
 
-  const workupType = enumName(reaction_pb.ReactionWorkup.ReactionWorkupType, workup.type) ?? '';
+  const workupType =
+    enumName(reaction_pb.ReactionWorkup.ReactionWorkupType, workup.type) ?? '';
   const duration = formattedTime(workup.duration);
   const aliquotAmount = workup.amount ? amountStr(amountObj(workup.amount)) : '';
 
@@ -102,7 +105,9 @@ const WorkupsView: React.FC<WorkupsViewProps> = ({ workup }) => {
           <div className="components">
             {workup.input.componentsList.map((component, idx) => (
               <React.Fragment key={idx}>
-                <div className="identifier">{getNameIdentifier(component.identifiersList)}</div>
+                <div className="identifier">
+                  {getNameIdentifier(component.identifiersList)}
+                </div>
                 <div className="amount">{amountStr(amountObj(component.amount))}</div>
               </React.Fragment>
             ))}

--- a/app/src/views/search/MainSearch.tsx
+++ b/app/src/views/search/MainSearch.tsx
@@ -76,23 +76,34 @@ const MainSearch: React.FC = () => {
 
     if (options.reagent.reagents.length) {
       options.reagent.reagents.forEach(reagent => {
-        searchParams.append('component', `${reagent.smileSmart};${reagent.source};${reagent.matchMode.toLowerCase()}`);
+        searchParams.append(
+          'component',
+          `${reagent.smileSmart};${reagent.source};${reagent.matchMode.toLowerCase()}`,
+        );
       });
-      searchParams.set('use_stereochemistry', options.reagent.useStereochemistry.toString());
+      searchParams.set(
+        'use_stereochemistry',
+        options.reagent.useStereochemistry.toString(),
+      );
       searchParams.set('similarity', options.reagent.similarityThreshold.toString());
     }
 
     options.dataset.datasetIds.forEach(id => searchParams.append('dataset_id', id));
     options.dataset.DOIs.forEach(doi => searchParams.append('doi', doi));
     options.reaction.reactionIds.forEach(id => searchParams.append('reaction_id', id));
-    options.reaction.reactionSmarts.forEach(smarts => searchParams.append('reaction_smarts', smarts));
+    options.reaction.reactionSmarts.forEach(smarts =>
+      searchParams.append('reaction_smarts', smarts),
+    );
 
     // Yield/conversion: only include when narrower than the full 0-100 range.
     if (options.reaction.min_yield !== 0 || options.reaction.max_yield !== 100) {
       searchParams.set('min_yield', options.reaction.min_yield.toString());
       searchParams.set('max_yield', options.reaction.max_yield.toString());
     }
-    if (options.reaction.min_conversion !== 0 || options.reaction.max_conversion !== 100) {
+    if (
+      options.reaction.min_conversion !== 0 ||
+      options.reaction.max_conversion !== 100
+    ) {
       searchParams.set('min_conversion', options.reaction.min_conversion.toString());
       searchParams.set('max_conversion', options.reaction.max_conversion.toString());
     }
@@ -104,7 +115,9 @@ const MainSearch: React.FC = () => {
 
   return (
     <div id="search-main">
-      <div className={`search-options-container ${showOptions ? 'slide-out' : 'hidden'}`}>
+      <div
+        className={`search-options-container ${showOptions ? 'slide-out' : 'hidden'}`}
+      >
         <div className="title">Filters & Options</div>
         <div className="options-holder">
           <SearchOptions onSearchOptions={updateSearchOptions} />
@@ -122,7 +135,10 @@ const MainSearch: React.FC = () => {
       <div className="search-results">
         {!hasSearchParams && (
           <div className="no-results">
-            <div className="title">Enter search criteria using the filters and options panel, then click Search.</div>
+            <div className="title">
+              Enter search criteria using the filters and options panel, then click
+              Search.
+            </div>
           </div>
         )}
         {hasSearchParams && error && (
@@ -135,7 +151,9 @@ const MainSearch: React.FC = () => {
         )}
         {hasSearchParams && !error && !loading && !searchResults.length && (
           <div className="no-results">
-            <div className="title">No results. Adjust the filters and options and search again.</div>
+            <div className="title">
+              No results. Adjust the filters and options and search again.
+            </div>
           </div>
         )}
         {hasSearchParams && !error && loading && (

--- a/app/src/views/search/SearchItemList.tsx
+++ b/app/src/views/search/SearchItemList.tsx
@@ -23,7 +23,11 @@ interface SearchItemListProps {
   onUpdateItemList: (newList: string[]) => void;
 }
 
-const SearchItemList: React.FC<SearchItemListProps> = ({ title, itemList, onUpdateItemList }) => {
+const SearchItemList: React.FC<SearchItemListProps> = ({
+  title,
+  itemList,
+  onUpdateItemList,
+}) => {
   const [mutatedList, setMutatedList] = useState<string[]>([]);
   const [itemToAdd, setItemToAdd] = useState<string>('');
 

--- a/app/src/views/search/SearchOptions.tsx
+++ b/app/src/views/search/SearchOptions.tsx
@@ -102,7 +102,9 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
 
   const [showKetcherModal, setShowKetcherModal] = useState(false);
   const [ketcherModalSmile, setKetcherModalSmile] = useState(0);
-  const [ketcherModalSet, setKetcherModalSet] = useState<'reactants' | 'products'>('reactants');
+  const [ketcherModalSet, setKetcherModalSet] = useState<'reactants' | 'products'>(
+    'reactants',
+  );
 
   const matchModes = ['exact', 'similar', 'substructure', 'SMARTS'];
 
@@ -137,10 +139,12 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
   };
 
   const emitSearchOptions = () => {
-    const allComponents = [...reagentOptions.reactants, ...reagentOptions.products].map(component => ({
-      ...component,
-      matchMode: reagentOptions.matchMode,
-    }));
+    const allComponents = [...reagentOptions.reactants, ...reagentOptions.products].map(
+      component => ({
+        ...component,
+        matchMode: reagentOptions.matchMode,
+      }),
+    );
 
     const searchOptions: SearchOptionsData = {
       reagent: {
@@ -189,7 +193,8 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
         }
       });
 
-      initialReagentOptions.useStereochemistry = q.use_stereochemistry === 'true' || false;
+      initialReagentOptions.useStereochemistry =
+        q.use_stereochemistry === 'true' || false;
       initialReagentOptions.similarityThreshold = Number(q.similarity) || 0.5;
 
       setReagentOptions(initialReagentOptions);
@@ -200,7 +205,11 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
     }
 
     // dataset options
-    const datasetIds = Array.isArray(q.dataset_id) ? q.dataset_id : q.dataset_id?.length ? [q.dataset_id] : [];
+    const datasetIds = Array.isArray(q.dataset_id)
+      ? q.dataset_id
+      : q.dataset_id?.length
+        ? [q.dataset_id]
+        : [];
     const DOIs = Array.isArray(q.doi) ? q.doi : q.doi?.length ? [q.doi] : [];
 
     setDatasetOptions({ datasetIds, DOIs });
@@ -209,7 +218,11 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
     }
 
     // reaction options
-    const reactionIds = Array.isArray(q.reaction_id) ? q.reaction_id : q.reaction_id?.length ? [q.reaction_id] : [];
+    const reactionIds = Array.isArray(q.reaction_id)
+      ? q.reaction_id
+      : q.reaction_id?.length
+        ? [q.reaction_id]
+        : [];
     const reactionSmarts = Array.isArray(q.reaction_smarts)
       ? q.reaction_smarts
       : q.reaction_smarts?.length
@@ -284,7 +297,9 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
   const updateProductSmiles = (idx: number, smiles: string) => {
     setReagentOptions(prev => ({
       ...prev,
-      products: prev.products.map((product, index) => (index === idx ? { ...product, smileSmart: smiles } : product)),
+      products: prev.products.map((product, index) =>
+        index === idx ? { ...product, smileSmart: smiles } : product,
+      ),
     }));
   };
 
@@ -323,7 +338,9 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
                   <div
                     key={mode}
                     className={`tab capitalize ${reagentOptions.matchMode === mode ? 'selected' : ''}`}
-                    onClick={() => setReagentOptions(prev => ({ ...prev, matchMode: mode }))}
+                    onClick={() =>
+                      setReagentOptions(prev => ({ ...prev, matchMode: mode }))
+                    }
                   >
                     {mode}
                   </div>
@@ -340,7 +357,12 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
                 id="stereo"
                 type="checkbox"
                 checked={reagentOptions.useStereochemistry}
-                onChange={e => setReagentOptions(prev => ({ ...prev, useStereochemistry: e.target.checked }))}
+                onChange={e =>
+                  setReagentOptions(prev => ({
+                    ...prev,
+                    useStereochemistry: e.target.checked,
+                  }))
+                }
               />
               {reagentOptions.matchMode === 'similar' && (
                 <>
@@ -355,7 +377,10 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
                       step="0.01"
                       value={reagentOptions.similarityThreshold}
                       onChange={e =>
-                        setReagentOptions(prev => ({ ...prev, similarityThreshold: Number(e.target.value) }))
+                        setReagentOptions(prev => ({
+                          ...prev,
+                          similarityThreshold: Number(e.target.value),
+                        }))
                       }
                     />
                   </div>
@@ -388,7 +413,9 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
                   </div>
                 </React.Fragment>
               ))}
-              {!reagentOptions.reactants?.length && <div className="copy">No components</div>}
+              {!reagentOptions.reactants?.length && (
+                <div className="copy">No components</div>
+              )}
               <div id="add-component">
                 <button
                   type="button"
@@ -425,7 +452,9 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
                   </div>
                 </React.Fragment>
               ))}
-              {!reagentOptions.products?.length && <div className="copy">No components</div>}
+              {!reagentOptions.products?.length && (
+                <div className="copy">No components</div>
+              )}
               <div id="add-component">
                 <button
                   type="button"
@@ -457,12 +486,16 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
           <SearchItemList
             title="Reaction IDs"
             itemList={reactionOptions.reactionIds}
-            onUpdateItemList={newList => setReactionOptions(prev => ({ ...prev, reactionIds: newList }))}
+            onUpdateItemList={newList =>
+              setReactionOptions(prev => ({ ...prev, reactionIds: newList }))
+            }
           />
           <SearchItemList
             title="Reaction SMARTS"
             itemList={reactionOptions.reactionSmarts}
-            onUpdateItemList={newList => setReactionOptions(prev => ({ ...prev, reactionSmarts: newList }))}
+            onUpdateItemList={newList =>
+              setReactionOptions(prev => ({ ...prev, reactionSmarts: newList }))
+            }
           />
 
           <div className="slider-input multi">
@@ -514,7 +547,10 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
                 step={1}
                 min={0}
                 max={100}
-                values={[reactionOptions.min_conversion, reactionOptions.max_conversion]}
+                values={[
+                  reactionOptions.min_conversion,
+                  reactionOptions.max_conversion,
+                ]}
                 onChange={values =>
                   setReactionOptions(prev => ({
                     ...prev,
@@ -562,12 +598,16 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
           <SearchItemList
             title="Dataset IDs"
             itemList={datasetOptions.datasetIds}
-            onUpdateItemList={newList => setDatasetOptions(prev => ({ ...prev, datasetIds: newList }))}
+            onUpdateItemList={newList =>
+              setDatasetOptions(prev => ({ ...prev, datasetIds: newList }))
+            }
           />
           <SearchItemList
             title="DOIs"
             itemList={datasetOptions.DOIs}
-            onUpdateItemList={newList => setDatasetOptions(prev => ({ ...prev, DOIs: newList }))}
+            onUpdateItemList={newList =>
+              setDatasetOptions(prev => ({ ...prev, DOIs: newList }))
+            }
           />
         </div>
       )}
@@ -587,7 +627,9 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
             type="number"
             min="0"
             value={searchParams.limit}
-            onChange={e => setSearchParams(prev => ({ ...prev, limit: Number(e.target.value) }))}
+            onChange={e =>
+              setSearchParams(prev => ({ ...prev, limit: Number(e.target.value) }))
+            }
           />
         </div>
         <div className="search-button">

--- a/ord_interface/api/conftest.py
+++ b/ord_interface/api/conftest.py
@@ -63,7 +63,11 @@ def test_client(test_postgres) -> Iterator[TestClient]:
     ):
         # NOTE(skearnes): Set ORD_INTERFACE_POSTGRES to use that database instead of a testing.postgresql instance.
         # To force the use of testing.postgresl, set ORD_INTERFACE_TESTING=TRUE.
-        if os.environ.get("ORD_INTERFACE_TESTING", "FALSE") == "FALSE" and not os.environ.get("ORD_INTERFACE_POSTGRES"):
-            stack.enter_context(patch.dict(os.environ, {"ORD_INTERFACE_POSTGRES": test_postgres.url()}))
+        if os.environ.get(
+            "ORD_INTERFACE_TESTING", "FALSE"
+        ) == "FALSE" and not os.environ.get("ORD_INTERFACE_POSTGRES"):
+            stack.enter_context(
+                patch.dict(os.environ, {"ORD_INTERFACE_POSTGRES": test_postgres.url()})
+            )
         logger.debug(f"ORD_INTERFACE_POSTGRES={os.environ['ORD_INTERFACE_POSTGRES']}")
         yield client

--- a/ord_interface/api/queries.py
+++ b/ord_interface/api/queries.py
@@ -149,7 +149,9 @@ class ReactionSmartsQuery(ReactionQuery):
 class ReactionConversionQuery(ReactionQuery):
     """Looks up reactions by conversion."""
 
-    def __init__(self, min_conversion: float | None, max_conversion: float | None) -> None:
+    def __init__(
+        self, min_conversion: float | None, max_conversion: float | None
+    ) -> None:
         """Initializes the query.
 
         Args:
@@ -157,7 +159,9 @@ class ReactionConversionQuery(ReactionQuery):
             max_conversion: Maximum conversion, as a percentage.
         """
         if min_conversion is None and max_conversion is None:
-            raise ValueError("At least one of min_conversion or max_conversion must be specified")
+            raise ValueError(
+                "At least one of min_conversion or max_conversion must be specified"
+            )
         self._min_conversion = min_conversion
         self._max_conversion = max_conversion
 
@@ -353,7 +357,9 @@ async def fetch_results(cursor: DictCursor) -> list[str]:
     """
     reaction_ids = set()
     async for row in cursor:
-        assert row["reaction_id"] not in reaction_ids  # Sanity check for well-written queries.
+        assert (
+            row["reaction_id"] not in reaction_ids
+        )  # Sanity check for well-written queries.
         reaction_ids.add(row["reaction_id"])
     return list(reaction_ids)
 
@@ -374,7 +380,9 @@ async def run_queries(
         List of reaction IDs.
     """
     queries_list: list[ReactionQuery] = (
-        [reaction_queries] if isinstance(reaction_queries, ReactionQuery) else reaction_queries
+        [reaction_queries]
+        if isinstance(reaction_queries, ReactionQuery)
+        else reaction_queries
     )
     queries, combined_params = [], []
     for reaction_query in queries_list:
@@ -406,10 +414,15 @@ class QueryResult(BaseModel):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, QueryResult):
             return NotImplemented
-        return self.dataset_id == other.dataset_id and self.reaction_id == other.reaction_id
+        return (
+            self.dataset_id == other.dataset_id
+            and self.reaction_id == other.reaction_id
+        )
 
 
-async def fetch_reactions(cursor: DictCursor, reaction_ids: list[str]) -> list[QueryResult]:
+async def fetch_reactions(
+    cursor: DictCursor, reaction_ids: list[str]
+) -> list[QueryResult]:
     """Fetches dataset and proto information for a list of reaction IDs."""
     query = """
         SELECT dataset.dataset_id, reaction.reaction_id, reaction.proto
@@ -422,7 +435,9 @@ async def fetch_reactions(cursor: DictCursor, reaction_ids: list[str]) -> list[Q
     async for row in cursor:
         results.append(
             QueryResult(
-                dataset_id=row["dataset_id"], reaction_id=row["reaction_id"], proto=b64encode(row["proto"]).decode()
+                dataset_id=row["dataset_id"],
+                reaction_id=row["reaction_id"],
+                proto=b64encode(row["proto"]).decode(),
             )
         )
     return results

--- a/ord_interface/api/queries_test.py
+++ b/ord_interface/api/queries_test.py
@@ -34,7 +34,9 @@ from ord_interface.api.queries import (
 
 @pytest.mark.asyncio
 async def test_fetch_reactions(test_cursor):
-    results = await fetch_reactions(test_cursor, ["ord-1e8382606d99485b9859da6a92f80a72"])
+    results = await fetch_reactions(
+        test_cursor, ["ord-1e8382606d99485b9859da6a92f80a72"]
+    )
     assert len(results) == 1
     result = results[0]
     assert result.dataset_id == "ord_dataset-b440f8c90b6343189093770060fc4098"
@@ -83,7 +85,9 @@ async def test_reaction_yield_query(test_cursor):
 async def test_doi_query(test_cursor):
     dois = ["10.1126/science.1255525"]
     query = DoiQuery(dois)
-    results = await fetch_reactions(test_cursor, await run_queries(test_cursor, query, limit=10))
+    results = await fetch_reactions(
+        test_cursor, await run_queries(test_cursor, query, limit=10)
+    )
     assert len(results) == 10
     for result in results:
         assert result.reaction.provenance.doi in dois
@@ -92,7 +96,9 @@ async def test_doi_query(test_cursor):
 @pytest.mark.asyncio
 async def test_exact_query(test_cursor):
     query = ReactionComponentQuery(
-        "[Br]C1=CC=C(C(C)=O)C=C1", ReactionComponentQuery.Target.INPUT, ReactionComponentQuery.MatchMode.EXACT
+        "[Br]C1=CC=C(C(C)=O)C=C1",
+        ReactionComponentQuery.Target.INPUT,
+        ReactionComponentQuery.MatchMode.EXACT,
     )
     results = await run_queries(test_cursor, query, limit=5)
     assert len(results) == 5
@@ -101,7 +107,9 @@ async def test_exact_query(test_cursor):
 @pytest.mark.asyncio
 async def test_substructure_query(test_cursor):
     query = ReactionComponentQuery(
-        "C", ReactionComponentQuery.Target.OUTPUT, ReactionComponentQuery.MatchMode.SUBSTRUCTURE
+        "C",
+        ReactionComponentQuery.Target.OUTPUT,
+        ReactionComponentQuery.MatchMode.SUBSTRUCTURE,
     )
     results = await run_queries(test_cursor, query, limit=10)
     assert len(results) == 10
@@ -110,12 +118,16 @@ async def test_substructure_query(test_cursor):
 @pytest.mark.asyncio
 async def test_chiral_substructure_query(test_cursor):
     query = ReactionComponentQuery(
-        "OC1CC(O)C1", ReactionComponentQuery.Target.INPUT, ReactionComponentQuery.MatchMode.SUBSTRUCTURE
+        "OC1CC(O)C1",
+        ReactionComponentQuery.Target.INPUT,
+        ReactionComponentQuery.MatchMode.SUBSTRUCTURE,
     )
     results = await run_queries(test_cursor, query, limit=10)
     assert len(results) == 10
     query = ReactionComponentQuery(
-        "O[C@H]1C[C@H](O)C1", ReactionComponentQuery.Target.INPUT, ReactionComponentQuery.MatchMode.SUBSTRUCTURE
+        "O[C@H]1C[C@H](O)C1",
+        ReactionComponentQuery.Target.INPUT,
+        ReactionComponentQuery.MatchMode.SUBSTRUCTURE,
     )
     results = await run_queries(test_cursor, query, limit=10)
     assert len(results) == 10
@@ -139,7 +151,11 @@ async def test_chiral_substructure_query(test_cursor):
 
 @pytest.mark.asyncio
 async def test_smarts_query(test_cursor):
-    query = ReactionComponentQuery("[#6]", ReactionComponentQuery.Target.INPUT, ReactionComponentQuery.MatchMode.SMARTS)
+    query = ReactionComponentQuery(
+        "[#6]",
+        ReactionComponentQuery.Target.INPUT,
+        ReactionComponentQuery.MatchMode.SMARTS,
+    )
     results = await run_queries(test_cursor, query, limit=10)
     assert len(results) == 10
 
@@ -163,19 +179,25 @@ async def test_similarity_query(test_cursor):
 async def test_bad_smiles(test_cursor):
     with pytest.raises(ValueError, match="Cannot parse pattern"):
         ReactionComponentQuery(
-            "invalid_smiles", ReactionComponentQuery.Target.INPUT, ReactionComponentQuery.MatchMode.SUBSTRUCTURE
+            "invalid_smiles",
+            ReactionComponentQuery.Target.INPUT,
+            ReactionComponentQuery.MatchMode.SUBSTRUCTURE,
         )
 
 
 @pytest.mark.asyncio
 async def test_fetch_dataset_most_used_smiles_for_inputs(test_cursor):
     dataset_id = "ord_dataset-89b083710e2d441aa0040c361d63359f"
-    results = await fetch_dataset_most_used_smiles_for_inputs(test_cursor, dataset_id, limit=10)
+    results = await fetch_dataset_most_used_smiles_for_inputs(
+        test_cursor, dataset_id, limit=10
+    )
     assert len(results) == 10
 
 
 @pytest.mark.asyncio
 async def test_fetch_dataset_most_used_smiles_for_products(test_cursor):
     dataset_id = "ord_dataset-89b083710e2d441aa0040c361d63359f"
-    results = await fetch_dataset_most_used_smiles_for_products(test_cursor, dataset_id, limit=10)
+    results = await fetch_dataset_most_used_smiles_for_products(
+        test_cursor, dataset_id, limit=10
+    )
     assert len(results) == 10

--- a/ord_interface/api/search.py
+++ b/ord_interface/api/search.py
@@ -27,7 +27,15 @@ from typing import Any, cast
 from uuid import uuid4
 
 import psycopg
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Response, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Response,
+    status,
+)
 from ord_schema.logging import get_logger
 from ord_schema.orm.database import get_connection_string
 from ord_schema.proto import dataset_pb2
@@ -92,7 +100,9 @@ async def get_redis() -> AsyncIterator[Redis]:
     async with Redis(host=host, port=port, ssl=ssl) as client:
         # redis.asyncio stubs return Awaitable[bool] | bool from ping(); the runtime is always awaitable.
         if not await cast(Awaitable[bool], client.ping()):
-            raise RuntimeError(f"Failed to connect to Redis server {host}:{port} ({ssl=})")
+            raise RuntimeError(
+                f"Failed to connect to Redis server {host}:{port} ({ssl=})"
+            )
         logger.debug(f"Connected to Redis server {host}:{port} ({ssl=})")
         yield client
 
@@ -117,7 +127,9 @@ class QueryParams:
     limit: int | None = None
 
 
-async def run_query(params: QueryParams, return_ids: bool) -> list[QueryResult] | list[str]:
+async def run_query(
+    params: QueryParams, return_ids: bool
+) -> list[QueryResult] | list[str]:
     """Runs a query and returns a list of matched reactions."""
     queries = []
     if params.dataset_id and isinstance(params.dataset_id, list):
@@ -127,7 +139,9 @@ async def run_query(params: QueryParams, return_ids: bool) -> list[QueryResult] 
     if params.reaction_smarts:
         queries.append(ReactionSmartsQuery(params.reaction_smarts))
     if params.min_conversion is not None or params.max_conversion is not None:
-        queries.append(ReactionConversionQuery(params.min_conversion, params.max_conversion))
+        queries.append(
+            ReactionConversionQuery(params.min_conversion, params.max_conversion)
+        )
     if params.min_yield is not None or params.max_yield is not None:
         queries.append(ReactionYieldQuery(params.min_yield, params.max_yield))
     if params.doi and isinstance(params.doi, list):
@@ -201,7 +215,9 @@ class DatasetInfo(BaseModel):
 async def get_datasets() -> list[DatasetInfo]:
     """Returns info about the current datasets."""
     async with get_cursor() as cursor:
-        await cursor.execute("SELECT dataset_id, name, description, num_reactions FROM dataset")
+        await cursor.execute(
+            "SELECT dataset_id, name, description, num_reactions FROM dataset"
+        )
         return [DatasetInfo(**row) async for row in cursor]
 
 
@@ -215,7 +231,9 @@ async def get_dataset(dataset_id: str) -> DatasetInfo:
         )
         row = await cursor.fetchone()
         if row is None:
-            raise HTTPException(status_code=404, detail=f"dataset not found: {dataset_id}")
+            raise HTTPException(
+                status_code=404, detail=f"dataset not found: {dataset_id}"
+            )
         return DatasetInfo(**row)
 
 
@@ -232,8 +250,12 @@ async def get_molfile(smiles: str) -> str:
 async def get_search_results(inputs: ReactionIdList):
     """Downloads search results as a Dataset proto."""
     results = await get_reactions(inputs)
-    dataset = dataset_pb2.Dataset(name="ORD Search Results", reactions=[result.reaction for result in results])
-    return Response(gzip.compress(dataset.SerializeToString()), media_type="application/gzip")
+    dataset = dataset_pb2.Dataset(
+        name="ORD Search Results", reactions=[result.reaction for result in results]
+    )
+    return Response(
+        gzip.compress(dataset.SerializeToString()), media_type="application/gzip"
+    )
 
 
 async def run_task(task_id: str, params: QueryParams) -> bool:
@@ -246,7 +268,9 @@ async def run_task(task_id: str, params: QueryParams) -> bool:
 
 
 @router.get("/submit_query")
-async def submit_query(background_tasks: BackgroundTasks, params: QueryParams = Depends()) -> str:
+async def submit_query(
+    background_tasks: BackgroundTasks, params: QueryParams = Depends()
+) -> str:
     """Submits a query as a background task."""
     task_id = str(uuid4())
     async with get_redis() as client:
@@ -261,10 +285,14 @@ async def fetch_query_result(task_id: str):
     """Checks the query status, returning the results if the query is complete."""
     async with get_redis() as client:
         if not await client.exists(f"query:{task_id}"):
-            return Response(f"Task {task_id} does not exist", status_code=status.HTTP_404_NOT_FOUND)
+            return Response(
+                f"Task {task_id} does not exist", status_code=status.HTTP_404_NOT_FOUND
+            )
         result = await client.get(f"result:{task_id}")
     if result is None:
-        return Response(f"Task {task_id} is pending", status_code=status.HTTP_202_ACCEPTED)
+        return Response(
+            f"Task {task_id} is pending", status_code=status.HTTP_202_ACCEPTED
+        )
     async with get_cursor() as cursor:
         return await fetch_reactions(cursor, json.loads(result))
 
@@ -272,12 +300,16 @@ async def fetch_query_result(task_id: str):
 @router.get("/input_stats")
 async def get_input_stats(dataset_id: str, limit: int = 30) -> list[StatsResult]:
     async with get_cursor() as cursor:
-        results = await fetch_dataset_most_used_smiles_for_inputs(cursor, dataset_id, limit=limit)
+        results = await fetch_dataset_most_used_smiles_for_inputs(
+            cursor, dataset_id, limit=limit
+        )
     return results
 
 
 @router.get("/product_stats")
 async def get_product_stats(dataset_id: str, limit: int = 30) -> list[StatsResult]:
     async with get_cursor() as cursor:
-        results = await fetch_dataset_most_used_smiles_for_products(cursor, dataset_id, limit=limit)
+        results = await fetch_dataset_most_used_smiles_for_products(
+            cursor, dataset_id, limit=limit
+        )
     return results

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -33,7 +33,13 @@ QUERY_PARAMS = [
     ({"doi": ["10.1126/science.1255525"]}, 24),
     ({"component": ["[Br]C1=CC=C(C(C)=O)C=C1;input;exact"]}, 10),
     ({"component": ["C;input;substructure"]}, 144),
-    ({"component": ["O[C@@H]1C[C@H](O)C1;input;substructure"], "use_stereochemistry": True}, 20),
+    (
+        {
+            "component": ["O[C@@H]1C[C@H](O)C1;input;substructure"],
+            "use_stereochemistry": True,
+        },
+        20,
+    ),
     ({"component": ["[#6];input;smarts"]}, 144),
     ({"component": ["CC=O;input;similar"], "similarity": 0.5}, 0),
     ({"component": ["CC=O;input;similar"], "similarity": 0.05}, 120),
@@ -42,7 +48,10 @@ QUERY_PARAMS = [
         {
             "min_yield": 50,
             "max_yield": 90,
-            "component": ["[Br]C1=CC=C(C(C)=O)C=C1;input;exact", "CC(C)(C)OC(=O)NC;input;substructure"],
+            "component": [
+                "[Br]C1=CC=C(C(C)=O)C=C1;input;exact",
+                "CC(C)(C)OC(=O)NC;input;substructure",
+            ],
         },
         7,
     ),
@@ -57,7 +66,9 @@ def test_query(test_client, params, num_expected):
 
 
 def test_get_reaction(test_client):
-    response = test_client.get("/api/reaction", params={"reaction_id": "ord-3f67aa5592fd434d97a577988d3fd241"})
+    response = test_client.get(
+        "/api/reaction", params={"reaction_id": "ord-3f67aa5592fd434d97a577988d3fd241"}
+    )
     response.raise_for_status()
     result = QueryResult(**response.json())
     assert result.dataset_id == "ord_dataset-89b083710e2d441aa0040c361d63359f"
@@ -65,7 +76,10 @@ def test_get_reaction(test_client):
 
 
 def test_get_reactions(test_client):
-    response = test_client.post("/api/reactions", json={"reaction_ids": ["ord-3f67aa5592fd434d97a577988d3fd241"]})
+    response = test_client.post(
+        "/api/reactions",
+        json={"reaction_ids": ["ord-3f67aa5592fd434d97a577988d3fd241"]},
+    )
     response.raise_for_status()
     reactions = response.json()
     assert len(reactions) == 1
@@ -88,7 +102,9 @@ def test_get_dataset(test_client):
 
 
 def test_get_dataset_not_found(test_client):
-    response = test_client.get("/api/dataset", params={"dataset_id": "ord_dataset-does-not-exist"})
+    response = test_client.get(
+        "/api/dataset", params={"dataset_id": "ord_dataset-does-not-exist"}
+    )
     assert response.status_code == 404
 
 
@@ -100,7 +116,8 @@ def test_get_molfile(test_client):
 
 def test_get_search_results(test_client):
     response = test_client.post(
-        "/api/download_search_results", json={"reaction_ids": ["ord-3f67aa5592fd434d97a577988d3fd241"]}
+        "/api/download_search_results",
+        json={"reaction_ids": ["ord-3f67aa5592fd434d97a577988d3fd241"]},
     )
     response.raise_for_status()
     dataset = dataset_pb2.Dataset.FromString(gzip.decompress(response.read()))
@@ -126,7 +143,11 @@ def test_query_async(test_client, params, num_expected):
 
 def test_get_input_stats(test_client):
     response = test_client.get(
-        "/api/input_stats", params={"dataset_id": "ord_dataset-89b083710e2d441aa0040c361d63359f", "limit": 10}
+        "/api/input_stats",
+        params={
+            "dataset_id": "ord_dataset-89b083710e2d441aa0040c361d63359f",
+            "limit": 10,
+        },
     )
     response.raise_for_status()
     input_stats = response.json()
@@ -135,7 +156,11 @@ def test_get_input_stats(test_client):
 
 def test_get_product_stats(test_client):
     response = test_client.get(
-        "/api/product_stats", params={"dataset_id": "ord_dataset-89b083710e2d441aa0040c361d63359f", "limit": 10}
+        "/api/product_stats",
+        params={
+            "dataset_id": "ord_dataset-89b083710e2d441aa0040c361d63359f",
+            "limit": 10,
+        },
     )
     response.raise_for_status()
     product_stats = response.json()

--- a/ord_interface/api/testing.py
+++ b/ord_interface/api/testing.py
@@ -28,7 +28,9 @@ def setup_test_postgres(url: str) -> None:
     """Adds test data to a postgres database."""
     datasets = [
         load_message(filename, dataset_pb2.Dataset)
-        for filename in glob(os.path.join(os.path.dirname(__file__), "testdata", "*.pb.gz"))
+        for filename in glob(
+            os.path.join(os.path.dirname(__file__), "testdata", "*.pb.gz")
+        )
     ]
     assert datasets
     engine = create_engine(url, future=True)

--- a/ord_interface/api/view.py
+++ b/ord_interface/api/view.py
@@ -42,6 +42,8 @@ async def get_reaction_summary(reaction_id: str, compact: bool = True) -> str:
     if len(results) == 0 or len(results) > 1:
         raise ValueError(reaction_id)
     try:
-        return generate_text.generate_html(reaction=results[0].reaction, compact=compact)
+        return generate_text.generate_html(
+            reaction=results[0].reaction, compact=compact
+        )
     except (ValueError, KeyError):
         return "[Reaction cannot be displayed]"

--- a/ord_interface/api/view_test.py
+++ b/ord_interface/api/view_test.py
@@ -20,10 +20,15 @@ from ord_schema.proto import reaction_pb2
 def test_get_compound_svg(test_client):
     compound = reaction_pb2.Compound()
     compound.identifiers.add(value="c1ccccc1", type="SMILES")
-    response = test_client.post("/api/compound_svg", content=compound.SerializeToString())
+    response = test_client.post(
+        "/api/compound_svg", content=compound.SerializeToString()
+    )
     response.raise_for_status()
 
 
 def test_get_reaction_summary(test_client):
-    response = test_client.get("/api/reaction_summary", params={"reaction_id": "ord-3f67aa5592fd434d97a577988d3fd241"})
+    response = test_client.get(
+        "/api/reaction_summary",
+        params={"reaction_id": "ord-3f67aa5592fd434d97a577988d3fd241"},
+    )
     response.raise_for_status()

--- a/ord_interface/client/build_database.py
+++ b/ord_interface/client/build_database.py
@@ -18,13 +18,23 @@ import logging
 from ord_schema.orm import database
 
 from ord_interface.api.testing import setup_test_postgres
-from ord_interface.client import POSTGRES_DB, POSTGRES_HOST, POSTGRES_PASSWORD, POSTGRES_PORT, POSTGRES_USER
+from ord_interface.client import (
+    POSTGRES_DB,
+    POSTGRES_HOST,
+    POSTGRES_PASSWORD,
+    POSTGRES_PORT,
+    POSTGRES_USER,
+)
 
 
 def main():
     logging.disable(logging.DEBUG)
     connection_string = database.get_connection_string(
-        database=POSTGRES_DB, username=POSTGRES_USER, password=POSTGRES_PASSWORD, host=POSTGRES_HOST, port=POSTGRES_PORT
+        database=POSTGRES_DB,
+        username=POSTGRES_USER,
+        password=POSTGRES_PASSWORD,
+        host=POSTGRES_HOST,
+        port=POSTGRES_PORT,
     )
     setup_test_postgres(connection_string)
 

--- a/ord_interface/visualization/drawing.py
+++ b/ord_interface/visualization/drawing.py
@@ -112,7 +112,9 @@ def mol_to_svg(
         return match.group(1)
 
 
-def _draw_svg(mol: Chem.Mol, size_x: int, size_y: int, bond_length: int) -> Draw.MolDraw2DSVG:
+def _draw_svg(
+    mol: Chem.Mol, size_x: int, size_y: int, bond_length: int
+) -> Draw.MolDraw2DSVG:
     """Creates a canvas and draws a SVG.
 
     Args:
@@ -132,7 +134,9 @@ def _draw_svg(mol: Chem.Mol, size_x: int, size_y: int, bond_length: int) -> Draw
     return drawer
 
 
-def mol_to_png(mol: Chem.Mol, max_size: int = 1000, bond_length: int = 25, png_quality: int = 70) -> str:
+def mol_to_png(
+    mol: Chem.Mol, max_size: int = 1000, bond_length: int = 25, png_quality: int = 70
+) -> str:
     """Creates a (cropped) PNG molecule drawing as a string.
 
     Args:

--- a/ord_interface/visualization/filters.py
+++ b/ord_interface/visualization/filters.py
@@ -37,7 +37,9 @@ def _is_true(boolean: Any) -> bool:
     return bool(boolean)
 
 
-def _count_addition_order(inputs: Mapping[str, reaction_pb2.ReactionInput]) -> Iterable[tuple[int, int]]:
+def _count_addition_order(
+    inputs: Mapping[str, reaction_pb2.ReactionInput],
+) -> Iterable[tuple[int, int]]:
     """Returns the number of inputs for each addition_order value.
 
     Args:
@@ -614,7 +616,9 @@ def _round(value: float, places=2) -> str:
     return f"{value:.{places}g}"
 
 
-def _datetimeformat(message: reaction_pb2.DateTime, format_string: str = "%Y-%m-%d / %H:%M") -> str:
+def _datetimeformat(
+    message: reaction_pb2.DateTime, format_string: str = "%Y-%m-%d / %H:%M"
+) -> str:
     """Formats a date/time string."""
     value = parser.parse(message.value)
     return value.strftime(format_string)
@@ -656,7 +660,9 @@ def _get_compact_products(
         reaction_pb2.ReactionRole.PRODUCT,
         reaction_pb2.ReactionRole.UNSPECIFIED,
     ]
-    return [compound for compound in products if compound.reaction_role in roles_to_keep]
+    return [
+        compound for compound in products if compound.reaction_role in roles_to_keep
+    ]
 
 
 def _value_and_precision(message) -> str:

--- a/ord_interface/visualization/generate_text.py
+++ b/ord_interface/visualization/generate_text.py
@@ -23,7 +23,9 @@ from ord_schema.proto import reaction_pb2
 from ord_interface.visualization import filters
 
 
-def _generate(reaction: reaction_pb2.Reaction, template_string: str, line_breaks: bool, **kwargs) -> str:
+def _generate(
+    reaction: reaction_pb2.Reaction, template_string: str, line_breaks: bool, **kwargs
+) -> str:
     """Renders a Jinja2 template string with a reaction message.
 
     Args:
@@ -56,7 +58,9 @@ def generate_text(reaction: reaction_pb2.Reaction) -> str:
     return _generate(reaction, template_string=template, line_breaks=False)
 
 
-def generate_html(reaction: reaction_pb2.Reaction, compact=False, bond_length: int | None = None) -> str:
+def generate_html(
+    reaction: reaction_pb2.Reaction, compact=False, bond_length: int | None = None
+) -> str:
     """Generates an HTML reaction description."""
     # Special handling for e.g. USPTO reactions.
     reaction_smiles = message_helpers.get_reaction_smiles(reaction)

--- a/ord_interface/visualization/generate_text_test.py
+++ b/ord_interface/visualization/generate_text_test.py
@@ -51,9 +51,13 @@ def reaction() -> Iterator[reaction_pb2.Reaction]:
             amount="catalytic",
         )
     )
-    reaction.conditions.pressure.atmosphere.type = reaction_pb2.PressureConditions.Atmosphere.OXYGEN
+    reaction.conditions.pressure.atmosphere.type = (
+        reaction_pb2.PressureConditions.Atmosphere.OXYGEN
+    )
     reaction.conditions.stirring.rate.rpm = 100
-    reaction.conditions.temperature.control.type = reaction_pb2.TemperatureConditions.TemperatureControl.OIL_BATH
+    reaction.conditions.temperature.control.type = (
+        reaction_pb2.TemperatureConditions.TemperatureControl.OIL_BATH
+    )
     reaction.conditions.temperature.setpoint.CopyFrom(
         reaction_pb2.Temperature(value=100, units=reaction_pb2.Temperature.CELSIUS)
     )
@@ -67,14 +71,32 @@ def reaction() -> Iterator[reaction_pb2.Reaction]:
 
 def test_text(reaction):
     text = generate_text.generate_text(reaction)
-    expected = ["vessel", "oil bath", "after 40 min", "as a solvent", "hexanone", "automatically", "mL", "catalytic"]
+    expected = [
+        "vessel",
+        "oil bath",
+        "after 40 min",
+        "as a solvent",
+        "hexanone",
+        "automatically",
+        "mL",
+        "catalytic",
+    ]
     for value in expected:
         assert value in text
 
 
 def test_html(reaction):
     html = generate_text.generate_html(reaction)
-    expected = ["<table", "hexanone", "under oxygen", "100 rpm", "40 min", "solvent", "100 °C", "catalytic"]
+    expected = [
+        "<table",
+        "hexanone",
+        "under oxygen",
+        "100 rpm",
+        "40 min",
+        "solvent",
+        "100 °C",
+        "catalytic",
+    ]
     for value in expected:
         assert value in html
 
@@ -84,7 +106,14 @@ def test_compact_html(reaction):
     expected = ["<table"]
     for value in expected:
         assert value in html
-    not_expected = ["hexanone", "under oxygen", "100 rpm", "40 min", "solvent", "100 °C"]
+    not_expected = [
+        "hexanone",
+        "under oxygen",
+        "100 rpm",
+        "40 min",
+        "solvent",
+        "100 °C",
+    ]
     for value in not_expected:
         assert value not in html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
 include = ["ord_interface*"]
 
 [tool.ruff]
-line-length = 120
+line-length = 88
 extend-exclude = [
     # Generated protobuf files: never touch.
     "*_pb2.py*",


### PR DESCRIPTION
## What

Mirrors [open-reaction-database/ord-schema#843](https://github.com/open-reaction-database/ord-schema/pull/843) in this repo, and extends the same line width to the JS/TS side for cross-language consistency.

- **Python** ([pyproject.toml](pyproject.toml)): `line-length` 120 → 88 (ruff's default); `ruff format .`.
- **JS/TS** ([app/.prettierrc.json](app/.prettierrc.json)): Prettier `printWidth` 120 → 88; `npm run format`.

**E501 stays ignored** — line length is enforced by the formatters (ruff / Prettier), not the linters, on both sides.

## Scope

Purely mechanical reflow plus the two config one-liners. No logic, API, or data changes. Unlike the upstream PR, there were no displaced `# noqa` / `# ty: ignore` pragmas to repair here.

## Verification

- `ruff check .` clean; `ruff format` leaves the tree stable.
- `npm run lint` (ESLint) clean; `npm run format:check` (Prettier) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces the Python `line-length` (ruff) and JS/TS `printWidth` (Prettier) from 120 to 88 characters across the entire repository, mirroring a companion change in `ord-schema`. All 37 non-config files contain purely mechanical line-wrap reformatting with no logic, API, or data changes.

- `pyproject.toml` and `app/.prettierrc.json` each have a single one-line config change that drives the reflow.
- Every other changed file is the deterministic output of `ruff format .` and `npm run format` — function signatures, import blocks, JSX callbacks, and string literals wrapped to the new width.

<h3>Confidence Score: 5/5</h3>

Safe to merge — every file change is the deterministic output of the two formatters with no hand-edited logic.

All 39 changed files contain only mechanical line-wrapping driven by two one-line config edits; no executable logic, API contracts, or data structures were touched. The PR description confirms ruff check and ESLint pass clean, and ruff format/prettier --check are stable.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Config change: line-length 120 → 88; the single driver of all Python reformatting in this PR. |
| app/.prettierrc.json | Config change: printWidth 120 → 88; the single driver of all JS/TS reformatting in this PR. |
| ord_interface/api/queries.py | Purely mechanical ruff reflow — function signatures, string literals, and inline expressions wrapped to 88 chars; no logic changes. |
| ord_interface/api/search.py | Purely mechanical ruff reflow — import block, function signatures, and call sites wrapped to 88 chars; no logic changes. |
| app/src/views/search/SearchOptions.tsx | Largest TS reflow in the PR — ternary chains, JSX conditionals, and callback bodies reformatted by Prettier; no logic changes. |
| app/src/views/reaction-view/MainReactionView.tsx | Mechanical Prettier reflow — array literals, Promise.all, and JSX map callbacks wrapped to 88 chars; no logic changes. |
| ord_interface/api/queries_test.py | Mechanical ruff reflow of test call sites; no assertion or test-logic changes. |
| ord_interface/visualization/generate_text.py | Two function signatures wrapped to 88 chars; no logic changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Adopt 88-char line length for Python and..."](https://github.com/open-reaction-database/ord-interface/commit/c29036c205f0685b10288df90a2926f0ed47d984) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38853778)</sub>

<!-- /greptile_comment -->