### PR TITLE
Remove Codecov from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,17 +53,7 @@ jobs:
         run: |
           uv run coverage erase
           uv run pytest -vv --cov=ord_interface --durations=20 --ignore=ord_interface/editor
-          uv run coverage xml
-      # Codecov uses CODECOV_TOKEN when set. Do not fail the job when uploads cannot authenticate:
-      # fork PRs (tokenless), Dependabot PRs (no repo secrets + protected dependabot/* branches).
-      # Pushes to main and normal same-repo PRs stay strict.
-      - uses: codecov/codecov-action@v5
-        with:
-          files: coverage.xml
-          # CODECOV_TOKEN is an org-wide token, so the repo slug must be explicit.
-          slug: open-reaction-database/ord-interface
-          fail_ci_if_error: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot/')) }}
-          token: ${{ secrets.CODECOV_TOKEN }}
+          uv run coverage report
 
   test_app:
     strategy:


### PR DESCRIPTION
## Summary

Mirrors [open-reaction-database/ord-schema#842](https://github.com/open-reaction-database/ord-schema/pull/842): removes Codecov to drop an external CI dependency. Codecov was **purely informational** here — it never gated merges and there's no README badge. It only provided the PR coverage comment and the codecov.io dashboard.

Coverage is still measured by `pytest --cov`; this just stops uploading it externally.

## Changes

- Drop the `codecov/codecov-action@v5` upload step in [.github/workflows/tests.yml](.github/workflows/tests.yml), along with its fork/Dependabot token-auth workarounds and the `CODECOV_TOKEN` / explicit-slug usage.
- Replace `coverage xml` with `coverage report` so the coverage summary still prints in the job log — no external service required.

There is no `codecov.yml` in this repo, so nothing to delete (unlike the upstream PR).

## Follow-up (outside this repo)

- Remove the `CODECOV_TOKEN` org/repo secret.
- Disable the Codecov GitHub App so it stops posting status checks with nothing to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the Codecov integration from the CI workflow. Coverage data is still collected via `pytest --cov` and printed in the job log via `coverage report`; only the external upload to codecov.io is dropped.

- Removes `codecov/codecov-action@v5` along with its fork/Dependabot token-auth workarounds and the `CODECOV_TOKEN` / `slug` configuration.
- Replaces `coverage xml` with `coverage report` so the coverage summary still appears in the GitHub Actions log without generating an artifact that nothing local consumes.

<h3>Confidence Score: 5/5</h3>

The change removes only the Codecov upload step and its surrounding workarounds; all test execution and coverage measurement remain intact.

The diff touches a single CI step: swapping `coverage xml` → `coverage report` and deleting the Codecov action. Coverage collection is unaffected, the test run is unaffected, and no conditional logic or secrets handling is introduced. The only downstream consequence is that codecov.io stops receiving uploads, which the author explicitly notes is intentional.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/tests.yml | Removes the Codecov upload step and replaces `coverage xml` with `coverage report` so coverage is still logged locally without any external service dependency. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove Codecov from CI"](https://github.com/open-reaction-database/ord-interface/commit/eccb9128bfeb66d40763885a0b46ba9638e21ef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38854769)</sub>

<!-- /greptile_comment -->