### PR TITLE
Uniformly schema-qualify ord-schema tables in queries

### DIFF
--- a/ord_interface/api/queries.py
+++ b/ord_interface/api/queries.py
@@ -89,7 +89,7 @@ class DatasetIdQuery(ReactionQuery):
         query = """
             SELECT DISTINCT reaction.reaction_id
             FROM ord.reaction
-            JOIN dataset ON dataset.id = reaction.dataset_id
+            JOIN ord.dataset ON dataset.id = reaction.dataset_id
             WHERE dataset.dataset_id = ANY (%s)
         """
         return query, [self._dataset_ids]
@@ -139,7 +139,7 @@ class ReactionSmartsQuery(ReactionQuery):
         """Returns the query and any query parameters."""
         query = """
             SELECT DISTINCT reaction.reaction_id
-            FROM reaction
+            FROM ord.reaction
             JOIN rdkit.reactions ON rdkit.reactions.id = reaction.rdkit_reaction_id
             WHERE rdkit.reactions.reaction @> reaction_from_smarts(%s)
         """
@@ -172,7 +172,7 @@ class ReactionConversionQuery(ReactionQuery):
             SELECT DISTINCT reaction.reaction_id
             FROM ord.reaction
             JOIN ord.reaction_outcome on reaction_outcome.reaction_id = reaction.id
-            JOIN percentage on percentage.reaction_outcome_id = reaction_outcome.id
+            JOIN ord.percentage on percentage.reaction_outcome_id = reaction_outcome.id
         """
         if self._min_conversion is not None and self._max_conversion is not None:
             query += "WHERE percentage.value >= %s AND percentage.value <= %s\n"
@@ -210,7 +210,7 @@ class ReactionYieldQuery(ReactionQuery):
             JOIN ord.reaction_outcome on reaction_outcome.reaction_id = reaction.id
             JOIN ord.product_compound on product_compound.reaction_outcome_id = reaction_outcome.id
             JOIN ord.product_measurement on product_measurement.product_compound_id = product_compound.id
-            JOIN percentage on percentage.product_measurement_id = product_measurement.id
+            JOIN ord.percentage on percentage.product_measurement_id = product_measurement.id
             WHERE product_measurement.type = 'YIELD'
         """
         params = []
@@ -250,7 +250,7 @@ class DoiQuery(ReactionQuery):
         query = """
             SELECT DISTINCT reaction.reaction_id
             FROM ord.reaction
-            JOIN reaction_provenance ON reaction_provenance.reaction_id = reaction.id
+            JOIN ord.reaction_provenance ON reaction_provenance.reaction_id = reaction.id
             WHERE reaction_provenance.doi = ANY (%s)
         """
         return query, [self._dois]
@@ -307,14 +307,14 @@ class ReactionComponentQuery(ReactionQuery):
         """Returns the query and any query parameters."""
         if self._target == ReactionComponentQuery.Target.INPUT:
             mols_sql = """
-            JOIN reaction_input ON reaction_input.reaction_id = reaction.id
-            JOIN compound ON compound.reaction_input_id = reaction_input.id
+            JOIN ord.reaction_input ON reaction_input.reaction_id = reaction.id
+            JOIN ord.compound ON compound.reaction_input_id = reaction_input.id
             JOIN rdkit.mols ON rdkit.mols.id = compound.rdkit_mol_id
             """
         else:
             mols_sql = """
-            JOIN reaction_outcome ON reaction_outcome.reaction_id = reaction.id
-            JOIN product_compound ON product_compound.reaction_outcome_id = reaction_outcome.id
+            JOIN ord.reaction_outcome ON reaction_outcome.reaction_id = reaction.id
+            JOIN ord.product_compound ON product_compound.reaction_outcome_id = reaction_outcome.id
             JOIN rdkit.mols ON rdkit.mols.id = product_compound.rdkit_mol_id
             """
         if self._match_mode == ReactionComponentQuery.MatchMode.EXACT:


### PR DESCRIPTION
## What

Completes the backend-consistency cleanup (Tier 2) by making `ord.` schema-qualification uniform across the reaction queries in [queries.py](ord_interface/api/queries.py). Previously the FROM/JOIN clauses mixed styles — `FROM reaction` vs `FROM ord.reaction`, `JOIN percentage` vs `JOIN ord.percentage`, etc.

## Why this is safe (cosmetic, not a correctness fix)

The connection sets `options="-c search_path=public,ord"` in both production ([search.py](ord_interface/api/search.py#L87)) and tests ([conftest.py](ord_interface/api/conftest.py#L49)), so bare `ord`-schema table names already resolve. This PR just makes the qualification explicit and uniform.

- **FROM/JOIN clauses**: all `ord`-schema tables now carry the `ord.` prefix, matching the convention already used by `fetch_reactions` and `_fetch_dataset_most_used_smiles`.
- **`rdkit.*` tables**: left prefixed — `rdkit` is *not* in the search_path, so the prefix is required there.
- **Column references**: left as bare table aliases (e.g. `reaction.dataset_id`), the dominant style throughout the file.

## Verification

- `ruff check` clean.
- `queries_test.py` + `search_test.py` — **51 passed** against the test Postgres, confirming no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR uniformly adds the `ord.` schema qualifier to all previously bare `ord`-schema table names in the SQL queries inside `queries.py`. Because the connection sets `search_path=public,ord` in both production and tests, this is a purely cosmetic consistency improvement with no behavior change.

- Eight FROM/JOIN table references (`dataset`, `reaction`, `percentage`, `reaction_provenance`, `reaction_input`, `compound`, `reaction_outcome`, `product_compound`) are now explicitly prefixed with `ord.`, matching the style already used in other queries in the same file.
- `rdkit.*` table references are intentionally left untouched since `rdkit` is not in the search path and already requires explicit qualification.
- The PR description notes all 51 tests pass, confirming no functional change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely cosmetic and the existing search_path configuration ensures both qualified and unqualified names resolve identically.

Every modified query already worked with bare table names because the connection sets search_path=public,ord. Adding explicit ord. prefixes cannot break resolution; it only removes the implicit dependency on search_path ordering. All rdkit.* references remain correctly prefixed. The scope is limited to a single file with no logic changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_interface/api/queries.py | Adds explicit ord. schema prefix to 8 previously bare table references in FROM/JOIN clauses; rdkit.* prefixes and column aliases are correctly left unchanged. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/open-reaction-database/ord-interface/commit/2d0a20a712d7c978a1792459288fb4032c4651d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38857845)</sub>

<!-- /greptile_comment -->