### PR TITLE
Reformat view.py to 88 chars to fix red check_python on main

### DIFF
--- a/ord_interface/api/view.py
+++ b/ord_interface/api/view.py
@@ -40,9 +40,13 @@ async def get_reaction_summary(reaction_id: str, compact: bool = True) -> str:
     """Renders a reaction as an HTML table with images and text."""
     results = await get_reactions(ReactionIdList(reaction_ids=[reaction_id]))
     if len(results) == 0:
-        raise HTTPException(status_code=404, detail=f"reaction not found: {reaction_id}")
+        raise HTTPException(
+            status_code=404, detail=f"reaction not found: {reaction_id}"
+        )
     if len(results) > 1:
-        raise HTTPException(status_code=500, detail=f"multiple reactions found: {reaction_id}")
+        raise HTTPException(
+            status_code=500, detail=f"multiple reactions found: {reaction_id}"
+        )
     try:
         return generate_text.generate_html(
             reaction=results[0].reaction, compact=compact

--- a/ord_interface/api/view_test.py
+++ b/ord_interface/api/view_test.py
@@ -35,5 +35,7 @@ def test_get_reaction_summary(test_client):
 
 
 def test_get_reaction_summary_not_found(test_client):
-    response = test_client.get("/api/reaction_summary", params={"reaction_id": "ord-does-not-exist"})
+    response = test_client.get(
+        "/api/reaction_summary", params={"reaction_id": "ord-does-not-exist"}
+    )
     assert response.status_code == 404


### PR DESCRIPTION
## What

`main`'s `check_python` job is currently **red**. #187 added two `HTTPException` calls in [view.py](ord_interface/api/view.py) (and one line in [view_test.py](ord_interface/api/view_test.py)) wider than 88 chars; it merged *after* #188 lowered the ruff line length to 88, without rebasing, so the `ruff format --check ord_interface` step has been failing on `main` ever since. #186 didn't touch these files.

This is a pure `ruff format` reflow of those lines — no behavior change. It unblocks CI on `main` (and on the other open cleanup PRs, whose `check_python` inherits the same tree).

## Verification
- `ruff format --check ord_interface` clean.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a pure `ruff format` reflow to bring two `HTTPException` calls in `view.py` and one test call in `view_test.py` within the 88-character line limit introduced in #188. There are no logic or behavior changes.

- **`view.py`**: Two `HTTPException` constructions (404 and 500) split across multiple lines to satisfy the 88-char limit.
- **`view_test.py`**: One `test_client.get(...)` call reformatted identically for the same reason.

<h3>Confidence Score: 5/5</h3>

Safe to merge — exclusively whitespace/line-wrap reformatting with zero behavior change.

All three modified call sites are mechanically identical after the reflow; the only difference is line-break placement. No logic, imports, or test assertions were altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_interface/api/view.py | Pure formatting reflow of two HTTPException calls to fit within the 88-character line limit — no logic changes. |
| ord_interface/api/view_test.py | One test call reflowed to 88 chars — identical behavior, no logic changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Reformat view.py to 88 chars to fix chec..."](https://github.com/open-reaction-database/ord-interface/commit/ff9dad93865b63c14bf9e17ae0472de50d381dcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38859465)</sub>

<!-- /greptile_comment -->