### PR TITLE
Add a query statement_timeout so broad searches fail fast

### DIFF
--- a/ord_interface/api/search.py
+++ b/ord_interface/api/search.py
@@ -66,6 +66,10 @@ router = APIRouter(tags=["client"])
 
 BOND_LENGTH = 20
 MAX_RESULTS = 1000
+_QUERY_TIMEOUT_DETAIL = (
+    "Query timed out; it may be too broad. Refine your search -- e.g. a more "
+    "specific substructure or a higher similarity threshold."
+)
 
 
 @asynccontextmanager
@@ -83,8 +87,13 @@ async def get_cursor() -> AsyncIterator[AsyncCursor[dict[str, Any]]]:
                 host=os.environ["POSTGRES_HOST"],
             ),
         )
+    # Cap query runtime so a pathological (e.g. very broad substructure) search
+    # fails fast with a clear message instead of hanging; tunable via env.
+    timeout_ms = int(os.getenv("ORD_INTERFACE_QUERY_TIMEOUT_MS", "30000"))
     async with await psycopg.AsyncConnection[dict[str, Any]].connect(
-        dsn, row_factory=dict_row, options="-c search_path=public,ord"
+        dsn,
+        row_factory=dict_row,
+        options=f"-c search_path=public,ord -c statement_timeout={timeout_ms}",
     ) as connection:
         await connection.set_read_only(True)
         async with connection.cursor() as cursor:
@@ -177,7 +186,10 @@ async def run_query(
 @router.get("/query")
 async def query(params: QueryParams = Depends()) -> list[QueryResult]:
     """Runs a query."""
-    result = await run_query(params, return_ids=False)
+    try:
+        result = await run_query(params, return_ids=False)
+    except psycopg.errors.QueryCanceled as error:
+        raise HTTPException(status_code=400, detail=_QUERY_TIMEOUT_DETAIL) from error
     return cast(list[QueryResult], result)  # Type hint.
 
 
@@ -261,7 +273,13 @@ async def get_search_results(inputs: ReactionIdList):
 async def run_task(task_id: str, params: QueryParams) -> bool:
     """Wraps run_query() as a background task."""
     # NOTE(skearnes): Use reaction IDs to avoid stuffing full protos into the result database.
-    result = await run_query(params, return_ids=True)
+    result: list[str] | dict[str, str]
+    try:
+        result = cast(list[str], await run_query(params, return_ids=True))
+    except psycopg.errors.QueryCanceled:
+        # Surface the timeout via fetch_query_result instead of leaving the task
+        # forever "pending".
+        result = {"error": "timeout"}
     logger.debug(f"Finished task {task_id}")
     async with get_redis() as client:
         return await client.set(f"result:{task_id}", json.dumps(result), ex=60 * 60)
@@ -293,8 +311,11 @@ async def fetch_query_result(task_id: str):
         return Response(
             f"Task {task_id} is pending", status_code=status.HTTP_202_ACCEPTED
         )
+    parsed = json.loads(result)
+    if isinstance(parsed, dict) and parsed.get("error") == "timeout":
+        raise HTTPException(status_code=400, detail=_QUERY_TIMEOUT_DETAIL)
     async with get_cursor() as cursor:
-        return await fetch_reactions(cursor, json.loads(result))
+        return await fetch_reactions(cursor, cast(list[str], parsed))
 
 
 @router.get("/input_stats")

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -15,7 +15,9 @@
 """Tests for ord_interface.api.search."""
 
 import gzip
+from unittest.mock import patch
 
+import psycopg
 import pytest
 from ord_schema.proto import dataset_pb2
 from rdkit import Chem
@@ -63,6 +65,19 @@ def test_query(test_client, params, num_expected):
     response = test_client.get("/api/query", params=params)
     response.raise_for_status()
     assert len(response.json()) == num_expected
+
+
+def test_query_timeout_returns_400(test_client):
+    """A query that hits statement_timeout surfaces a helpful 400, not a 500/hang."""
+    with patch(
+        "ord_interface.api.search.run_queries",
+        side_effect=psycopg.errors.QueryCanceled,
+    ):
+        response = test_client.get(
+            "/api/query", params={"component": ["C;input;substructure"]}
+        )
+    assert response.status_code == 400
+    assert "broad" in response.json()["detail"].lower()
 
 
 def test_get_reaction(test_client):


### PR DESCRIPTION
Substructure/similarity search is ~150 ms for selective patterns, but a pathological *broad* pattern (e.g. bare benzene) can run for many seconds. This caps query runtime so those fail fast with a helpful message instead of hanging.

- `get_cursor` sets `statement_timeout` (default **30 s**, tunable via `ORD_INTERFACE_QUERY_TIMEOUT_MS`).
- The resulting `QueryCanceled` becomes a **400** with a clear detail ("too broad; refine your search — a more specific substructure or a higher similarity threshold") on:
  - the synchronous `/query` path, and
  - the async `submit_query` → `fetch_query_result` path (`run_task` stores a `{"error": "timeout"}` marker so the task doesn't sit "pending" forever).

Normal queries are unaffected (the existing suite passes under the 30 s cap). Added `test_query_timeout_returns_400` (mocks `QueryCanceled` for a deterministic check of the 400 path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a PostgreSQL `statement_timeout` (default 30 s, tunable via `ORD_INTERFACE_QUERY_TIMEOUT_MS`) to every database connection opened by `get_cursor()`, so pathologically broad substructure/similarity searches fail fast rather than hanging. The resulting `QueryCanceled` exception is translated to a user-friendly HTTP 400 on both the synchronous `/query` path and the async `submit_query` / `fetch_query_result` path.

- `get_cursor()` injects `-c statement_timeout=<ms>` into the connection options string, applying the cap uniformly to all DB connections.
- `run_task` catches `QueryCanceled` and stores an `{"error": "timeout"}` sentinel in Redis, which `fetch_query_result` detects and converts to a 400 instead of leaving the task forever "pending".
- A new unit test mocks `run_queries` to raise `QueryCanceled` and confirms the 400 + descriptive detail message on the sync path.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core timeout logic is correct and the happy path is unchanged. The two flagged items are operational polish rather than functional defects.

The timeout is wired correctly at the psycopg connection level, the QueryCanceled → 400 translation works on both code paths, and the existing test suite was verified to pass under the 30 s cap. The two concerns are: (1) int() on ORD_INTERFACE_QUERY_TIMEOUT_MS without a fallback will crash every cursor creation if an operator passes a non-integer value like '30s', turning a narrow config mistake into a service-wide outage; and (2) background-task timeouts produce no distinguishable log output, making them hard to detect in production. Neither affects normal operation.

ord_interface/api/search.py — specifically the env-var parsing in get_cursor() and the silent exception handling in run_task.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_interface/api/search.py | Adds statement_timeout to every DB connection, catches QueryCanceled on both the sync /query path and the async run_task path, and surfaces a 400 with a user-friendly message. Two minor concerns: the int() conversion of the env var has no error handling, and background-task timeouts are logged at debug/no distinction from successes. |
| ord_interface/api/search_test.py | Adds test_query_timeout_returns_400 which mocks run_queries to raise QueryCanceled and verifies the 400 status and "broad" keyword in the detail message. Covers the sync path; no async-path timeout test is added. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add a query statement\_timeout so broad s..."](https://github.com/open-reaction-database/ord-interface/commit/8e700762c213a5676ee23fbf3ffd92df0da9a354) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39465636)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->