### PR TITLE
Left-align About page text instead of justifying

### DIFF
--- a/app/src/views/About.scss
+++ b/app/src/views/About.scss
@@ -42,8 +42,7 @@
   }
 
   &__text {
-    text-align: justify;
-    text-justify: inter-word;
+    text-align: left;
     margin-bottom: 1rem;
     line-height: 1.6;
   }


### PR DESCRIPTION
The `/about` page paragraphs used `text-align: justify; text-justify: inter-word;`, which produces uneven word spacing ("rivers") — especially on narrower columns. Switch to `text-align: left` for clean, readable text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the styling of the `/about` page paragraphs to use left-aligned text instead of justified text, removing the `text-justify: inter-word` property as well.

- Replaces `text-align: justify` + `text-justify: inter-word` with `text-align: left` in the `__text` modifier rule in `About.scss`, eliminating the "rivers" of whitespace that justified text produces on narrow columns.

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal CSS-only change with no logic or data implications.

The change removes two text-alignment declarations and replaces them with a single standard `text-align: left`, which is the browser default for LTR text. The diff is one file, three lines, and the change is cosmetic-only with no functional side effects.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/views/About.scss | Removes `text-align: justify` and `text-justify: inter-word`, replacing them with `text-align: left` to eliminate uneven word spacing on the About page. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Left-align About page text instead of ju..."](https://github.com/open-reaction-database/ord-interface/commit/f85eaa389cbf615cd59591f9d9b79d8cbb88ee7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39467480)</sub>

<!-- /greptile_comment -->