### PR TITLE
Browse: clamp descriptions and add a dataset detail card; drop Submitted column

### DIFF
--- a/app/src/components/FloatingModal.tsx
+++ b/app/src/components/FloatingModal.tsx
@@ -18,15 +18,18 @@ import React, { type ReactNode } from 'react';
 import './FloatingModal.scss';
 
 interface FloatingModalProps {
-  title: string;
+  title: ReactNode;
   children: ReactNode;
   onCloseModal: () => void;
+  // Optional extra class on the modal container, for per-use sizing overrides.
+  className?: string;
 }
 
 const FloatingModal: React.FC<FloatingModalProps> = ({
   title,
   children,
   onCloseModal,
+  className,
 }) => {
   return (
     <div className="modal-main">
@@ -35,7 +38,7 @@ const FloatingModal: React.FC<FloatingModalProps> = ({
         onClick={onCloseModal}
       />
       <div className="modal-holder">
-        <div className="modal-container">
+        <div className={`modal-container${className ? ` ${className}` : ''}`}>
           <div className="header">
             <div className="modal-title">{title}</div>
             <div

--- a/app/src/views/browse/MainBrowse.scss
+++ b/app/src/views/browse/MainBrowse.scss
@@ -21,7 +21,17 @@
   padding: 1rem 0;
 
   .table-container {
-    grid-template-columns: 1fr 1fr 1fr auto auto;
+    // minmax(0, 1fr) (rather than 1fr) lets the flexible columns shrink to
+    // their share instead of being widened by long content like descriptions
+    // or dataset IDs, which would otherwise overflow the table.
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto auto;
+  }
+
+  // Allow cells to shrink below their content's intrinsic width, and wrap long
+  // unbreakable tokens (e.g. dataset IDs) instead of overflowing.
+  .column {
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
   .description-cell {

--- a/app/src/views/browse/MainBrowse.scss
+++ b/app/src/views/browse/MainBrowse.scss
@@ -24,14 +24,38 @@
     grid-template-columns: 1fr 1fr 1fr auto auto;
   }
 
+  .description-cell {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
   // Clamp long descriptions to a few lines (with an ellipsis) based on the
   // available column width, rather than a fixed character count.
-  .column.description {
+  .description-text {
+    flex: 1;
+    min-width: 0;
     display: -webkit-box;
     -webkit-line-clamp: 3;
     line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+
+  .expand-button {
+    flex: none;
+    display: inline-flex;
+    padding: 0.15rem;
+    border: none;
+    background: none;
+    color: vars.$linkblue;
+    cursor: pointer;
+    opacity: 0.6;
+
+    &:hover {
+      color: vars.$hoverblue;
+      opacity: 1;
+    }
   }
 
   .loading {

--- a/app/src/views/browse/MainBrowse.scss
+++ b/app/src/views/browse/MainBrowse.scss
@@ -24,7 +24,7 @@
     // minmax(0, 1fr) (rather than 1fr) lets the flexible columns shrink to
     // their share instead of being widened by long content like descriptions
     // or dataset IDs, which would otherwise overflow the table.
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto auto;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
   }
 
   // Allow cells to shrink below their content's intrinsic width, and wrap long
@@ -71,4 +71,37 @@
   .loading {
     margin-top: 30vh;
   }
+}
+
+// Description modal: size to its content (capped) instead of the shared modal's
+// fixed height, so short descriptions don't leave empty space below.
+.modal-main .modal-container.description-modal {
+  height: auto;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+
+  .body {
+    height: auto;
+    flex: 1;
+    min-height: 0;
+  }
+}
+
+.modal-dataset-id {
+  font-family: monospace;
+  font-size: 1rem;
+  font-weight: 400;
+  margin-top: 0.25rem;
+}
+
+.modal-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1.5rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.modal-description {
+  white-space: pre-wrap;
 }

--- a/app/src/views/browse/MainBrowse.scss
+++ b/app/src/views/browse/MainBrowse.scss
@@ -34,6 +34,10 @@
     overflow-wrap: anywhere;
   }
 
+  .column.size {
+    text-align: right;
+  }
+
   .description-cell {
     display: flex;
     align-items: flex-start;

--- a/app/src/views/browse/MainBrowse.scss
+++ b/app/src/views/browse/MainBrowse.scss
@@ -24,6 +24,16 @@
     grid-template-columns: 1fr 1fr 1fr auto auto;
   }
 
+  // Clamp long descriptions to a few lines (with an ellipsis) based on the
+  // available column width, rather than a fixed character count.
+  .column.description {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
   .loading {
     margin-top: 30vh;
   }

--- a/app/src/views/browse/MainBrowse.tsx
+++ b/app/src/views/browse/MainBrowse.tsx
@@ -45,11 +45,6 @@ const MainBrowse: React.FC = () => {
       });
   }, []);
 
-  const truncateDescription = (description?: string) => {
-    if (!description) return '';
-    return description.length > 75 ? description.substr(0, 75) + '...' : description;
-  };
-
   if (loading) {
     return (
       <div id="browse-main">
@@ -89,7 +84,7 @@ const MainBrowse: React.FC = () => {
                   <Link to={`/dataset/${row.dataset_id}`}>{row.dataset_id}</Link>
                 </div>
                 <div className="column">{row.name}</div>
-                <div className="column">{truncateDescription(row.description)}</div>
+                <div className="column description">{row.description}</div>
                 <div className="column">{row.num_reactions}</div>
                 <div className="column">{row.submitted_at ?? '—'}</div>
               </React.Fragment>

--- a/app/src/views/browse/MainBrowse.tsx
+++ b/app/src/views/browse/MainBrowse.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import EntityTable from '../../components/EntityTable';
+import FloatingModal from '../../components/FloatingModal';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import './MainBrowse.scss';
 
@@ -27,6 +28,70 @@ interface Dataset {
   num_reactions: number;
   submitted_at?: string | null;
 }
+
+// Description cell that clamps long text and, only when the text is actually
+// clipped, offers an expand button that shows the full description in a
+// floating modal (so the table layout never reflows).
+const DescriptionCell: React.FC<{ name: string; description?: string }> = ({
+  name,
+  description,
+}) => {
+  const textRef = useRef<HTMLDivElement>(null);
+  const [isClamped, setIsClamped] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  useLayoutEffect(() => {
+    const element = textRef.current;
+    if (!element) return;
+    const check = () => setIsClamped(element.scrollHeight > element.clientHeight + 1);
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [description]);
+
+  return (
+    <div className="column description-cell">
+      <div
+        ref={textRef}
+        className="description-text"
+      >
+        {description}
+      </div>
+      {isClamped && (
+        <button
+          type="button"
+          className="expand-button"
+          aria-label="Show full description"
+          title="Show full description"
+          onClick={() => setExpanded(true)}
+        >
+          <svg
+            viewBox="0 0 16 16"
+            width="14"
+            height="14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M6 2H2v4M10 2h4v4M6 14H2v-4M10 14h4v-4" />
+          </svg>
+        </button>
+      )}
+      {expanded && (
+        <FloatingModal
+          title={name}
+          onCloseModal={() => setExpanded(false)}
+        >
+          {description}
+        </FloatingModal>
+      )}
+    </div>
+  );
+};
 
 const MainBrowse: React.FC = () => {
   const [loading, setLoading] = useState(true);
@@ -84,7 +149,10 @@ const MainBrowse: React.FC = () => {
                   <Link to={`/dataset/${row.dataset_id}`}>{row.dataset_id}</Link>
                 </div>
                 <div className="column">{row.name}</div>
-                <div className="column description">{row.description}</div>
+                <DescriptionCell
+                  name={row.name}
+                  description={row.description}
+                />
                 <div className="column">{row.num_reactions}</div>
                 <div className="column">{row.submitted_at ?? '—'}</div>
               </React.Fragment>

--- a/app/src/views/browse/MainBrowse.tsx
+++ b/app/src/views/browse/MainBrowse.tsx
@@ -153,9 +153,7 @@ const MainBrowse: React.FC = () => {
                   submittedAt={row.submitted_at}
                   numReactions={row.num_reactions}
                 />
-                <div className="column size">
-                  {row.num_reactions.toLocaleString()}
-                </div>
+                <div className="column size">{row.num_reactions.toLocaleString()}</div>
               </React.Fragment>
             ))}
           </div>

--- a/app/src/views/browse/MainBrowse.tsx
+++ b/app/src/views/browse/MainBrowse.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import EntityTable from '../../components/EntityTable';
 import FloatingModal from '../../components/FloatingModal';
@@ -29,64 +29,62 @@ interface Dataset {
   submitted_at?: string | null;
 }
 
-// Description cell that clamps long text and, only when the text is actually
-// clipped, offers an expand button that shows the full description in a
-// floating modal (so the table layout never reflows).
-const DescriptionCell: React.FC<{ name: string; description?: string }> = ({
-  name,
-  description,
-}) => {
-  const textRef = useRef<HTMLDivElement>(null);
-  const [isClamped, setIsClamped] = useState(false);
+// Description cell: the text is clamped to a few lines, and an always-present
+// button opens a floating "card" modal with the dataset's full details. The
+// modal overlay means the table layout never reflows.
+const DescriptionCell: React.FC<{
+  datasetId: string;
+  name: string;
+  description?: string;
+  submittedAt?: string | null;
+  numReactions: number;
+}> = ({ datasetId, name, description, submittedAt, numReactions }) => {
   const [expanded, setExpanded] = useState(false);
-
-  useLayoutEffect(() => {
-    const element = textRef.current;
-    if (!element) return;
-    const check = () => setIsClamped(element.scrollHeight > element.clientHeight + 1);
-    check();
-    const observer = new ResizeObserver(check);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [description]);
 
   return (
     <div className="column description-cell">
-      <div
-        ref={textRef}
-        className="description-text"
+      <div className="description-text">{description}</div>
+      <button
+        type="button"
+        className="expand-button"
+        aria-label="Show dataset details"
+        title="Show dataset details"
+        onClick={() => setExpanded(true)}
       >
-        {description}
-      </div>
-      {isClamped && (
-        <button
-          type="button"
-          className="expand-button"
-          aria-label="Show full description"
-          title="Show full description"
-          onClick={() => setExpanded(true)}
+        <svg
+          viewBox="0 0 16 16"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
         >
-          <svg
-            viewBox="0 0 16 16"
-            width="14"
-            height="14"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M6 2H2v4M10 2h4v4M6 14H2v-4M10 14h4v-4" />
-          </svg>
-        </button>
-      )}
+          <path d="M6 2H2v4M10 2h4v4M6 14H2v-4M10 14h4v-4" />
+        </svg>
+      </button>
       {expanded && (
         <FloatingModal
-          title={name}
+          title={
+            <>
+              {name}
+              <div className="modal-dataset-id">{datasetId}</div>
+            </>
+          }
+          className="description-modal"
           onCloseModal={() => setExpanded(false)}
         >
-          {description}
+          <div className="modal-meta">
+            <span>
+              <strong>Submitted:</strong> {submittedAt ?? '—'}
+            </span>
+            <span>
+              <strong>Reactions:</strong> {numReactions.toLocaleString()}
+            </span>
+          </div>
+          <div className="modal-description">{description}</div>
         </FloatingModal>
       )}
     </div>
@@ -142,7 +140,6 @@ const MainBrowse: React.FC = () => {
             <div className="column label">Name</div>
             <div className="column label">Description</div>
             <div className="column label">Size</div>
-            <div className="column label">Submitted</div>
             {entities.map(row => (
               <React.Fragment key={row.dataset_id}>
                 <div className="column">
@@ -150,11 +147,13 @@ const MainBrowse: React.FC = () => {
                 </div>
                 <div className="column">{row.name}</div>
                 <DescriptionCell
+                  datasetId={row.dataset_id}
                   name={row.name}
                   description={row.description}
+                  submittedAt={row.submitted_at}
+                  numReactions={row.num_reactions}
                 />
                 <div className="column">{row.num_reactions}</div>
-                <div className="column">{row.submitted_at ?? '—'}</div>
               </React.Fragment>
             ))}
           </div>

--- a/app/src/views/browse/MainBrowse.tsx
+++ b/app/src/views/browse/MainBrowse.tsx
@@ -139,7 +139,7 @@ const MainBrowse: React.FC = () => {
             <div className="column label">Dataset ID</div>
             <div className="column label">Name</div>
             <div className="column label">Description</div>
-            <div className="column label">Size</div>
+            <div className="column label size">Size</div>
             {entities.map(row => (
               <React.Fragment key={row.dataset_id}>
                 <div className="column">
@@ -153,7 +153,9 @@ const MainBrowse: React.FC = () => {
                   submittedAt={row.submitted_at}
                   numReactions={row.num_reactions}
                 />
-                <div className="column">{row.num_reactions}</div>
+                <div className="column size">
+                  {row.num_reactions.toLocaleString()}
+                </div>
               </React.Fragment>
             ))}
           </div>

--- a/ord_interface/nginx.conf
+++ b/ord_interface/nginx.conf
@@ -34,21 +34,6 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
-        # Vite emits content-hashed asset filenames, so they can be cached
-        # indefinitely.
-        location /assets/ {
-            root /app/ord-interface/spa;
-            add_header Cache-Control "public, max-age=31536000, immutable";
-        }
-
-        # index.html points at the current hashed bundle, so it must always be
-        # revalidated; otherwise clients keep loading a stale build until a hard
-        # refresh.
-        location = /index.html {
-            root /app/ord-interface/spa;
-            add_header Cache-Control "no-cache";
-        }
-
         location /api/ {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/ord_interface/nginx.conf
+++ b/ord_interface/nginx.conf
@@ -34,6 +34,21 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
+        # Vite emits content-hashed asset filenames, so they can be cached
+        # indefinitely.
+        location /assets/ {
+            root /app/ord-interface/spa;
+            add_header Cache-Control "public, max-age=31536000, immutable";
+        }
+
+        # index.html points at the current hashed bundle, so it must always be
+        # revalidated; otherwise clients keep loading a stale build until a hard
+        # refresh.
+        location = /index.html {
+            root /app/ord-interface/spa;
+            add_header Cache-Control "no-cache";
+        }
+
         location /api/ {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Browse-page description UX. (The `index.html` cache fix originally bundled here moved to #202.)

## Description column
- Replaced the fixed **75-character** cut with a width-adaptive **3-line CSS clamp** (with ellipsis). Full text stays in the DOM, so `EntityTable` search still matches on it.
- Fixed grid overflow: the flexible columns use `minmax(0, 1fr)` (not `1fr`) and cells can shrink / wrap long dataset IDs, so long content no longer pushes columns off the right edge.

## Dataset detail "card" modal
- Every description cell has an always-present expand button that opens a `FloatingModal` styled as a dataset card: the **name** (header) with the **dataset ID** (monospace) beneath it, then **submitted date**, **reaction count**, and the **full description**.
- The modal sizes to its content (capped at 80vh) so short descriptions don't leave empty space, and the overlay means the table never reflows.

## Dropped the standalone "Submitted" column
It didn't earn its width; the submission date now lives in the card. **Datasets are still ordered newest-first by submission date server-side** — only the visible column was removed.

## Supporting change
`FloatingModal` gains an optional `className` (for per-use sizing) and its `title` now accepts a `ReactNode` (for the name + ID header). Existing string callers are unaffected.

## Testing
- `tsc -b`, `eslint`, and `vite build`: clean.
- Verified visually against production data via the local dev server (clamp, overflow, card modal, ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the hard-coded 75-character description truncation with a CSS `line-clamp` approach and adds a floating dataset-detail card modal accessible from every description cell; the standalone "Submitted" column is dropped in favor of showing the date inside the card.

- **`FloatingModal`** receives two new optional props — `className` for per-instance sizing and `title: ReactNode` for richer headers — with no impact on existing callers.
- **`MainBrowse`** extracts a new `DescriptionCell` component that CSS-clamps description text, keeps the full text in the DOM for `EntityTable` search, and conditionally renders a `FloatingModal` card with name, dataset ID, submission date, and reaction count.
- **Grid layout** is corrected by switching flexible columns from `1fr` to `minmax(0, 1fr)` and adding `min-width: 0; overflow-wrap: anywhere` to cells, preventing long dataset IDs from overflowing the table.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely additive UI improvements with no data-path or API changes.

All three files touch only presentation logic: the FloatingModal API extension is backward-compatible, the DescriptionCell is a self-contained component with local state, and the CSS corrections (minmax grid columns, clamp, flex modal sizing) are straightforward. No server calls, routing, or shared state are modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/components/FloatingModal.tsx | Backward-compatible API extension: title widened from string to ReactNode, optional className prop added for per-use sizing overrides; no logic changes. |
| app/src/views/browse/MainBrowse.tsx | Removes truncateDescription helper; adds DescriptionCell component with CSS-clamped text and a FloatingModal card; drops Submitted column and brings reaction count to 4-column grid. |
| app/src/views/browse/MainBrowse.scss | Fixes grid overflow with minmax(0, 1fr); adds -webkit-line-clamp description truncation; styles expand button, dataset-card modal (height:auto/flex overrides), and right-aligned size column. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Apply Prettier formatting to MainBrowse"](https://github.com/open-reaction-database/ord-interface/commit/f13631156c9fde20958f55430bb4acb610661abd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39719668)</sub>

<!-- /greptile_comment -->