### PR TITLE
Stop caching index.html so deploys take effect immediately

### DIFF
--- a/ord_interface/nginx.conf
+++ b/ord_interface/nginx.conf
@@ -17,6 +17,16 @@ http {
     gzip on;
     gzip_disable "msie6";
 
+    # Cache policy keyed on the (possibly rewritten) request path: content-hashed
+    # Vite assets are immutable, the SPA entry point must always be revalidated,
+    # and everything else (proxied API/editor responses) is left untouched. An
+    # empty value makes nginx omit the header entirely.
+    map $uri $cache_control {
+        default      "";
+        ~^/assets/   "public, max-age=31536000, immutable";
+        /index.html  "no-cache";
+    }
+
     upstream fastapi {
         server unix:/run/fastapi.sock max_fails=3 fail_timeout=60s;
     }
@@ -28,25 +38,15 @@ http {
     server {
         listen 8080;
 
+        # Set once at the server level (rather than per-location) so it isn't
+        # shadowed by, and doesn't shadow, any add_header directives a location
+        # may define later. The value comes from the $cache_control map above.
+        add_header Cache-Control $cache_control;
+
         location / {
             root /app/ord-interface/spa;
             index index.html;
             try_files $uri $uri/ /index.html;
-        }
-
-        # Vite emits content-hashed asset filenames, so they can be cached
-        # indefinitely.
-        location /assets/ {
-            root /app/ord-interface/spa;
-            add_header Cache-Control "public, max-age=31536000, immutable";
-        }
-
-        # index.html points at the current hashed bundle, so it must always be
-        # revalidated; otherwise clients keep loading a stale build until a hard
-        # refresh.
-        location = /index.html {
-            root /app/ord-interface/spa;
-            add_header Cache-Control "no-cache";
         }
 
         location /api/ {

--- a/ord_interface/nginx.conf
+++ b/ord_interface/nginx.conf
@@ -34,6 +34,21 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
+        # Vite emits content-hashed asset filenames, so they can be cached
+        # indefinitely.
+        location /assets/ {
+            root /app/ord-interface/spa;
+            add_header Cache-Control "public, max-age=31536000, immutable";
+        }
+
+        # index.html points at the current hashed bundle, so it must always be
+        # revalidated; otherwise clients keep loading a stale build until a hard
+        # refresh.
+        location = /index.html {
+            root /app/ord-interface/spa;
+            add_header Cache-Control "no-cache";
+        }
+
         location /api/ {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Split out from #201.

nginx served `index.html` with `ETag`/`Last-Modified` but **no `Cache-Control`**, so browsers heuristically cached it and kept loading the previous build's hashed bundle until a manual hard refresh (this is why a freshly deployed UI change didn't appear without one).

- `index.html` → `Cache-Control: no-cache` (always revalidate; cheap 304s via the existing ETag).
- `/assets/` (Vite content-hashed, immutable) → `Cache-Control: public, max-age=31536000, immutable`.

New deploys are picked up on the next normal navigation, with no stale-asset risk.

## Testing
- `nginx -t` against the updated config: syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes browser heuristic caching of `index.html` that prevented freshly deployed UI changes from appearing without a hard refresh. A `map` directive keyed on `$uri` drives a single server-level `add_header Cache-Control $cache_control`, routing Vite content-hashed assets to `public, max-age=31536000, immutable` and the SPA entry point to `no-cache`.

- Placing the directive at the server block rather than duplicating it in every `location` block correctly avoids the `add_header` inheritance pitfall flagged on the previous attempt.
- Empty string values in the map (`default \"\"`) cause nginx to suppress the header entirely for proxied API/editor responses, which is the correct behavior.
- The `try_files $uri $uri/ /index.html` fallback and the `index index.html` resolution both perform an internal redirect that updates `$uri` to `/index.html` before the response-filter phase, so the `no-cache` policy is applied to all SPA routes—not just literal `/index.html` requests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted nginx caching fix with no logic changes to the application code.

The map + server-level add_header approach is correct: empty values suppress the header for proxied routes, the /index.html pattern covers all SPA routes served via try_files/index rewrites, and assets get a proper immutable policy. No correctness issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_interface/nginx.conf | Adds a map-based Cache-Control policy: no-cache for index.html, immutable for /assets/, and no header for API/editor routes; header is set once at the server level to avoid add_header inheritance surprises. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Set SPA cache headers via a server-level..."](https://github.com/open-reaction-database/ord-interface/commit/126544a9ad368a031d973b592ce9fc8f0c5c25e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39720182)</sub>

<!-- /greptile_comment -->