### PR TITLE
Add /ask natural-language search page (frontend)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,6 +24,7 @@ import About from './views/About';
 import MainBrowse from './views/browse/MainBrowse';
 import MainSelectedSet from './views/browse/selected-set/MainSelectedSet';
 import MainSearch from './views/search/MainSearch';
+import MainNLSearch from './views/nl-search/MainNLSearch';
 import MainDatasetView from './views/dataset-view/MainDatasetView';
 import MainReactionView from './views/reaction-view/MainReactionView';
 import './App.scss';
@@ -54,6 +55,10 @@ const AppContent: React.FC = () => {
         <Route
           path="/search"
           element={<MainSearch />}
+        />
+        <Route
+          path="/ask"
+          element={<MainNLSearch />}
         />
         <Route
           path="/dataset/:datasetId"

--- a/app/src/components/HeaderNav.tsx
+++ b/app/src/components/HeaderNav.tsx
@@ -50,6 +50,12 @@ const HeaderNav: React.FC = () => {
               >
                 Search
               </Link>
+              <Link
+                className="nav-link header-nav__link"
+                to="/ask"
+              >
+                Ask
+              </Link>
             </div>
             <div className="nav-item header-nav__nav-item">
               <a

--- a/app/src/hooks/useNLQuery.ts
+++ b/app/src/hooks/useNLQuery.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import reaction_pb from 'ord-schema';
+import { base64ToBytes } from '../utils/base64';
+import { fetchJson } from '../utils/api';
+import type {
+  NLInterpretation,
+  NLQueryResponse,
+  ResolvedComponent,
+  SearchResult,
+} from '../types/search';
+
+export interface NLQueryData {
+  interpretation: NLInterpretation;
+  resolvedComponents: ResolvedComponent[];
+  results: SearchResult[];
+}
+
+/**
+ * Runs a natural-language search against `/api/nl_query`.
+ *
+ * Unlike structured search, the backend translates and executes in a single
+ * synchronous request, so this is a plain fetch rather than the submit/poll
+ * protocol of {@link useSearchTask}. Result protos are deserialized here the
+ * same way, and the model's interpretation is surfaced so the page can show the
+ * user how their question was understood.
+ */
+export function useNLQuery(query: string | null, enabled: boolean) {
+  return useQuery<NLQueryData>({
+    queryKey: ['nl-query', query],
+    enabled: enabled && query !== null && query.trim() !== '',
+    retry: false,
+    staleTime: Infinity,
+    queryFn: async (): Promise<NLQueryData> => {
+      const raw = await fetchJson<NLQueryResponse>(
+        `/api/nl_query?q=${encodeURIComponent(query as string)}`,
+        undefined,
+        'nl_query',
+      );
+      const results: SearchResult[] = raw.results.map(r => ({
+        ...r,
+        data: reaction_pb.Reaction.deserializeBinary(
+          new Uint8Array(base64ToBytes(r.proto)),
+        ).toObject(),
+      }));
+      return {
+        interpretation: raw.interpretation,
+        resolvedComponents: raw.resolved_components,
+        results,
+      };
+    },
+  });
+}

--- a/app/src/types/search.ts
+++ b/app/src/types/search.ts
@@ -49,3 +49,42 @@ export interface Dataset {
   description?: string;
   num_reactions: number;
 }
+
+// Mirrors ord_interface.api.nl_query.NLComponent.
+export interface NLComponent {
+  identifier: string;
+  target: 'INPUT' | 'OUTPUT';
+  mode: 'EXACT' | 'SIMILAR' | 'SUBSTRUCTURE' | 'SMARTS';
+}
+
+// Mirrors ord_interface.api.nl_query.NLQuery: how the model understood the
+// question. Component-level constraints plus optional numeric/flag filters.
+export interface NLInterpretation {
+  components: NLComponent[];
+  min_yield?: number | null;
+  max_yield?: number | null;
+  min_conversion?: number | null;
+  max_conversion?: number | null;
+  reaction_smarts?: string | null;
+  similarity_threshold?: number | null;
+  use_stereochemistry?: boolean | null;
+  limit?: number | null;
+}
+
+// Mirrors ord_interface.api.nl_query.ResolvedComponent: a component after its
+// name has been resolved to a concrete SMILES (shown for transparency).
+export interface ResolvedComponent {
+  identifier: string;
+  smiles: string;
+  resolver: string;
+  target: 'INPUT' | 'OUTPUT';
+  mode: 'EXACT' | 'SIMILAR' | 'SUBSTRUCTURE' | 'SMARTS';
+}
+
+// Raw /api/nl_query payload, before result protos are deserialized.
+export interface NLQueryResponse {
+  query: string;
+  interpretation: NLInterpretation;
+  resolved_components: ResolvedComponent[];
+  results: Omit<SearchResult, 'data'>[];
+}

--- a/app/src/views/nl-search/MainNLSearch.scss
+++ b/app/src/views/nl-search/MainNLSearch.scss
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.nl-search {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+
+  &__title {
+    margin-bottom: 0.25rem;
+  }
+
+  &__subtitle {
+    color: #555;
+    margin-bottom: 1.5rem;
+  }
+
+  &__form {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  &__input {
+    flex: 1;
+    padding: 0.6rem 0.75rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+
+  &__button {
+    padding: 0.6rem 1.25rem;
+    font-size: 1rem;
+    border: none;
+    border-radius: 4px;
+    background: #1a73e8;
+    color: #fff;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: default;
+    }
+  }
+
+  &__examples {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  &__example {
+    padding: 0.3rem 0.6rem;
+    font-size: 0.85rem;
+    border: 1px solid #d0d7de;
+    border-radius: 999px;
+    background: #f6f8fa;
+    color: #1a73e8;
+    cursor: pointer;
+  }
+
+  &__interpretation {
+    margin: 1.5rem 0;
+    padding: 0.75rem 1rem;
+    background: #f6f8fa;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+  }
+
+  &__interpretation-title {
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+  }
+
+  &__interpretation-list {
+    margin: 0;
+    padding-left: 1.2rem;
+
+    code {
+      color: #b5179e;
+    }
+  }
+
+  &__role {
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.03em;
+    color: #777;
+  }
+
+  &__mode,
+  &__resolver {
+    color: #777;
+    font-size: 0.85rem;
+  }
+
+  &__error {
+    margin: 1.5rem 0;
+    padding: 0.75rem 1rem;
+    background: #fde8e8;
+    border: 1px solid #f5b5b5;
+    border-radius: 6px;
+    color: #8a1f1f;
+  }
+
+  &__empty {
+    margin: 1.5rem 0;
+    color: #555;
+  }
+}

--- a/app/src/views/nl-search/MainNLSearch.tsx
+++ b/app/src/views/nl-search/MainNLSearch.tsx
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import SearchResults from '../search/SearchResults';
+import { useNLQuery } from '../../hooks/useNLQuery';
+import type { NLQueryData } from '../../hooks/useNLQuery';
+import './MainNLSearch.scss';
+
+const EXAMPLES = [
+  'reactions for synthesizing ibuprofen',
+  'reactions using benzene as an input with yield greater than 70%',
+  'reactions that make an aryl boronic acid',
+];
+
+/** Renders the model's interpretation so users can see how their question was read. */
+const Interpretation: React.FC<{ data: NLQueryData }> = ({ data }) => {
+  const { interpretation, resolvedComponents } = data;
+  const filters: string[] = [];
+  if (interpretation.min_yield != null)
+    filters.push(`yield ≥ ${interpretation.min_yield}%`);
+  if (interpretation.max_yield != null)
+    filters.push(`yield ≤ ${interpretation.max_yield}%`);
+  if (interpretation.min_conversion != null)
+    filters.push(`conversion ≥ ${interpretation.min_conversion}%`);
+  if (interpretation.max_conversion != null)
+    filters.push(`conversion ≤ ${interpretation.max_conversion}%`);
+  if (interpretation.reaction_smarts)
+    filters.push(`reaction SMARTS ${interpretation.reaction_smarts}`);
+  if (interpretation.use_stereochemistry) filters.push('stereochemistry respected');
+
+  return (
+    <div className="nl-search__interpretation">
+      <div className="nl-search__interpretation-title">Interpreted as:</div>
+      <ul className="nl-search__interpretation-list">
+        {resolvedComponents.map((component, index) => (
+          <li key={index}>
+            <span className="nl-search__role">
+              {component.target === 'OUTPUT' ? 'product' : 'reactant/reagent'}
+            </span>{' '}
+            <strong>{component.identifier}</strong>{' '}
+            <span className="nl-search__mode">({component.mode.toLowerCase()})</span>{' '}
+            <code>{component.smiles}</code>{' '}
+            <span className="nl-search__resolver">via {component.resolver}</span>
+          </li>
+        ))}
+        {filters.map((filter, index) => (
+          <li key={`filter-${index}`}>{filter}</li>
+        ))}
+        {resolvedComponents.length === 0 && filters.length === 0 && (
+          <li>(no constraints extracted)</li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+const MainNLSearch: React.FC = () => {
+  // The submitted query lives in the URL (?q=…) so searches are shareable and
+  // survive reloads, mirroring the structured search page.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const submittedQuery = searchParams.get('q');
+  const [input, setInput] = useState(submittedQuery ?? '');
+
+  const { data, isFetching, error } = useNLQuery(submittedQuery, true);
+
+  const submit = (value: string) => {
+    const trimmed = value.trim();
+    setInput(trimmed);
+    if (trimmed) {
+      setSearchParams({ q: trimmed });
+    } else {
+      setSearchParams({});
+    }
+  };
+
+  return (
+    <div className="nl-search">
+      <h1 className="nl-search__title">Ask about reactions</h1>
+      <p className="nl-search__subtitle">
+        Describe what you&apos;re looking for in plain language — compound names are
+        resolved to structures and matched against the database.
+      </p>
+
+      <form
+        className="nl-search__form"
+        onSubmit={event => {
+          event.preventDefault();
+          submit(input);
+        }}
+      >
+        <input
+          className="nl-search__input"
+          type="text"
+          value={input}
+          placeholder="e.g. reactions using benzene as an input with yield greater than 70%"
+          onChange={event => setInput(event.target.value)}
+        />
+        <button className="nl-search__button" type="submit" disabled={isFetching}>
+          {isFetching ? 'Searching…' : 'Search'}
+        </button>
+      </form>
+
+      <div className="nl-search__examples">
+        {EXAMPLES.map(example => (
+          <button
+            key={example}
+            type="button"
+            className="nl-search__example"
+            onClick={() => submit(example)}
+          >
+            {example}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="nl-search__error">{(error as Error).message}</div>
+      )}
+
+      {data && submittedQuery && (
+        <>
+          <Interpretation data={data} />
+          {data.results.length > 0 ? (
+            <SearchResults searchResults={data.results} />
+          ) : (
+            <div className="nl-search__empty">
+              No reactions matched. Try relaxing a filter, or rephrase the query.
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default MainNLSearch;


### PR DESCRIPTION
Follow-up to #203 (the natural-language query backend). Adds the web UI for `/api/nl_query`.

- A dedicated **/ask** page (`MainNLSearch`), separate from `/search`, with an "Interpreted as:" panel (roles, modes, resolved SMILES, resolver), example chips, and shareable `?q=` URLs; reuses `SearchResults`.
- `useNLQuery` hook — calls `/api/nl_query` and deserializes the result protos.
- NL types in `app/src/types/search.ts`; `/ask` route in `App.tsx`; "Ask" nav link in `HeaderNav`.

**Depends on #203** (the `/api/nl_query` endpoint). Draft until that merges; will rebase on `main` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)