### PR TITLE
Speed up structural search: most-selective-first predicates + statement timeout

### DIFF
--- a/ord_interface/api/queries.py
+++ b/ord_interface/api/queries.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from base64 import b64decode, b64encode
 from enum import Enum, auto
-from typing import Any, LiteralString
+from typing import Any, LiteralString, cast
 
 from ord_schema import message_helpers, validations
 from ord_schema.logging import get_logger
@@ -65,8 +65,20 @@ class ReactionQuery(ABC):
 
     @property
     @abstractmethod
-    def query_and_parameters(self) -> tuple[str, list]:
-        """Returns the query and any query parameters."""
+    def where_predicate(self) -> tuple[str, list]:
+        """Returns a boolean SQL predicate plus its parameters.
+
+        The predicate is evaluated against a single outer ``ord.reaction`` row
+        (aliased ``reaction``) in ``run_queries`` -- typically an ``EXISTS (...)``
+        correlated subquery. Combining predicates with ``AND`` over ``ord.reaction``
+        lets the planner lead with the most selective one (a semi-join) and stop
+        early under ``LIMIT``, rather than materializing one ``SELECT DISTINCT`` per
+        predicate and intersecting them.
+
+        Returns:
+            A ``(predicate_sql, params)`` tuple; ``params`` fill the predicate's
+            ``%s`` placeholders in order.
+        """
 
     @property
     def session_config(self) -> dict[str, str]:
@@ -98,15 +110,16 @@ class DatasetIdQuery(ReactionQuery):
         self._dataset_ids = dataset_ids
 
     @property
-    def query_and_parameters(self) -> tuple[str, list]:
-        """Returns the query and any query parameters."""
-        query = """
-            SELECT DISTINCT reaction.reaction_id
-            FROM ord.reaction
-            JOIN ord.dataset ON dataset.id = reaction.dataset_id
-            WHERE dataset.dataset_id = ANY (%s)
+    def where_predicate(self) -> tuple[str, list]:
+        """Returns the query predicate and any query parameters."""
+        predicate = """
+            EXISTS (
+                SELECT 1 FROM ord.dataset
+                WHERE dataset.id = reaction.dataset_id
+                AND dataset.dataset_id = ANY (%s)
+            )
         """
-        return query, [self._dataset_ids]
+        return predicate, [self._dataset_ids]
 
 
 class ReactionIdQuery(ReactionQuery):
@@ -124,14 +137,9 @@ class ReactionIdQuery(ReactionQuery):
         self._reaction_ids = reaction_ids
 
     @property
-    def query_and_parameters(self) -> tuple[str, list]:
-        """Returns the query and any query parameters."""
-        query = """
-            SELECT DISTINCT reaction.reaction_id
-            FROM ord.reaction
-            WHERE reaction.reaction_id = ANY (%s)
-        """
-        return query, [self._reaction_ids]
+    def where_predicate(self) -> tuple[str, list]:
+        """Returns the query predicate and any query parameters."""
+        return "reaction.reaction_id = ANY (%s)", [self._reaction_ids]
 
 
 class ReactionSmartsQuery(ReactionQuery):
@@ -149,15 +157,16 @@ class ReactionSmartsQuery(ReactionQuery):
         self._reaction_smarts = reaction_smarts
 
     @property
-    def query_and_parameters(self) -> tuple[str, list]:
-        """Returns the query and any query parameters."""
-        query = """
-            SELECT DISTINCT reaction.reaction_id
-            FROM ord.reaction
-            JOIN rdkit.reactions ON rdkit.reactions.id = reaction.rdkit_reaction_id
-            WHERE rdkit.reactions.reaction @> reaction_from_smarts(%s)
+    def where_predicate(self) -> tuple[str, list]:
+        """Returns the query predicate and any query parameters."""
+        predicate = """
+            EXISTS (
+                SELECT 1 FROM rdkit.reactions
+                WHERE rdkit.reactions.id = reaction.rdkit_reaction_id
+                AND rdkit.reactions.reaction @> reaction_from_smarts(%s)
+            )
         """
-        return query, [self._reaction_smarts]
+        return predicate, [self._reaction_smarts]
 
 
 class ReactionConversionQuery(ReactionQuery):
@@ -180,24 +189,25 @@ class ReactionConversionQuery(ReactionQuery):
         self._max_conversion = max_conversion
 
     @property
-    def query_and_parameters(self) -> tuple[str, list]:
-        """Returns the query and any query parameters."""
-        query = """
-            SELECT DISTINCT reaction.reaction_id
-            FROM ord.reaction
-            JOIN ord.reaction_outcome on reaction_outcome.reaction_id = reaction.id
-            JOIN ord.percentage on percentage.reaction_outcome_id = reaction_outcome.id
-        """
+    def where_predicate(self) -> tuple[str, list]:
+        """Returns the query predicate and any query parameters."""
         if self._min_conversion is not None and self._max_conversion is not None:
-            query += "WHERE percentage.value >= %s AND percentage.value <= %s\n"
+            condition = "percentage.value >= %s AND percentage.value <= %s"
             params = [self._min_conversion, self._max_conversion]
         elif self._min_conversion is not None:
-            query += "WHERE percentage.value >= %s\n"
+            condition = "percentage.value >= %s"
             params = [self._min_conversion]
         else:
-            query += "WHERE percentage.value <= %s\n"
+            condition = "percentage.value <= %s"
             params = [self._max_conversion]
-        return query, params
+        predicate = f"""
+            EXISTS (
+                SELECT 1 FROM ord.reaction_outcome
+                JOIN ord.percentage ON percentage.reaction_outcome_id = reaction_outcome.id
+                WHERE reaction_outcome.reaction_id = reaction.id AND {condition}
+            )
+        """
+        return predicate, params
 
 
 class ReactionYieldQuery(ReactionQuery):
@@ -216,25 +226,26 @@ class ReactionYieldQuery(ReactionQuery):
         self._max_yield = max_yield
 
     @property
-    def query_and_parameters(self) -> tuple[str, list]:
-        """Returns the query and any query parameters."""
-        query = """
-            SELECT DISTINCT reaction.reaction_id
-            FROM ord.reaction
-            JOIN ord.reaction_outcome on reaction_outcome.reaction_id = reaction.id
-            JOIN ord.product_compound on product_compound.reaction_outcome_id = reaction_outcome.id
-            JOIN ord.product_measurement on product_measurement.product_compound_id = product_compound.id
-            JOIN ord.percentage on percentage.product_measurement_id = product_measurement.id
-            WHERE product_measurement.type = 'YIELD'
-        """
+    def where_predicate(self) -> tuple[str, list]:
+        """Returns the query predicate and any query parameters."""
+        conditions = "product_measurement.type = 'YIELD'"
         params = []
         if self._min_yield is not None:
-            query += "AND percentage.value >= %s\n"
+            conditions += " AND percentage.value >= %s"
             params.append(self._min_yield)
         if self._max_yield is not None:
-            query += "AND percentage.value <= %s\n"
+            conditions += " AND percentage.value <= %s"
             params.append(self._max_yield)
-        return query, params
+        predicate = f"""
+            EXISTS (
+                SELECT 1 FROM ord.reaction_outcome
+                JOIN ord.product_compound ON product_compound.reaction_outcome_id = reaction_outcome.id
+                JOIN ord.product_measurement ON product_measurement.product_compound_id = product_compound.id
+                JOIN ord.percentage ON percentage.product_measurement_id = product_measurement.id
+                WHERE reaction_outcome.reaction_id = reaction.id AND {conditions}
+            )
+        """
+        return predicate, params
 
 
 class DoiQuery(ReactionQuery):
@@ -259,15 +270,16 @@ class DoiQuery(ReactionQuery):
         self._dois = parsed_dois
 
     @property
-    def query_and_parameters(self) -> tuple[str, list]:
-        """Returns the query and any query parameters."""
-        query = """
-            SELECT DISTINCT reaction.reaction_id
-            FROM ord.reaction
-            JOIN ord.reaction_provenance ON reaction_provenance.reaction_id = reaction.id
-            WHERE reaction_provenance.doi = ANY (%s)
+    def where_predicate(self) -> tuple[str, list]:
+        """Returns the query predicate and any query parameters."""
+        predicate = """
+            EXISTS (
+                SELECT 1 FROM ord.reaction_provenance
+                WHERE reaction_provenance.reaction_id = reaction.id
+                AND reaction_provenance.doi = ANY (%s)
+            )
         """
-        return query, [self._dois]
+        return predicate, [self._dois]
 
 
 class ReactionComponentQuery(ReactionQuery):
@@ -332,14 +344,34 @@ class ReactionComponentQuery(ReactionQuery):
             """
 
     @property
+    def _mols_source(self) -> LiteralString:
+        """Returns the component tables and the correlation to the outer ``reaction`` row.
+
+        The FROM list starts at the component table (not ``ord.reaction``) so it can be
+        used inside a correlated ``EXISTS`` against the outer ``reaction`` alias.
+        """
+        if self._target == ReactionComponentQuery.Target.INPUT:
+            return """
+            ord.reaction_input
+            JOIN ord.compound ON compound.reaction_input_id = reaction_input.id
+            JOIN rdkit.mols ON rdkit.mols.id = compound.rdkit_mol_id
+            WHERE reaction_input.reaction_id = reaction.id
+            """
+        return """
+            ord.reaction_outcome
+            JOIN ord.product_compound ON product_compound.reaction_outcome_id = reaction_outcome.id
+            JOIN rdkit.mols ON rdkit.mols.id = product_compound.rdkit_mol_id
+            WHERE reaction_outcome.reaction_id = reaction.id
+            """
+
+    @property
     def is_similarity(self) -> bool:
         """Whether this is a similarity query, whose matches can be ranked by score."""
         return self._match_mode == ReactionComponentQuery.MatchMode.SIMILAR
 
     @property
-    def query_and_parameters(self) -> tuple[str, list]:
-        """Returns the query and any query parameters."""
-        mols_sql = self._mols_join
+    def where_predicate(self) -> tuple[str, list]:
+        """Returns the query predicate and any query parameters."""
         if self._match_mode == ReactionComponentQuery.MatchMode.EXACT:
             predicate_sql = "rdkit.mols.smiles = %s"
             params = [Chem.CanonSmiles(self._pattern)]
@@ -358,13 +390,12 @@ class ReactionComponentQuery(ReactionQuery):
             params = [self._pattern]
         else:
             raise NotImplementedError(f"Unsupported match_mode: {self._match_mode}")
-        query = f"""
-            SELECT DISTINCT reaction.reaction_id
-            FROM ord.reaction
-            {mols_sql}
-            WHERE {predicate_sql}
+        predicate = f"""
+            EXISTS (
+                SELECT 1 FROM {self._mols_source} AND {predicate_sql}
+            )
         """
-        return query, params
+        return predicate, params
 
     def similarity_score_query(self) -> tuple[LiteralString, list]:
         """Returns a query ranking reactions by similarity, plus its leading parameter.
@@ -459,11 +490,11 @@ async def run_queries(
     # several, results are returned unordered.
     ranking_query = similarity_queries[0] if len(similarity_queries) == 1 else None
 
-    queries, combined_params = [], []
+    predicates, combined_params = [], []
     config: dict[str, str] = {}
     for reaction_query in queries_list:
-        query, params = reaction_query.query_and_parameters
-        queries.append(query)
+        predicate, params = reaction_query.where_predicate
+        predicates.append(predicate)
         combined_params.extend(params)
         for name, value in reaction_query.session_config.items():
             existing = config.setdefault(name, value)
@@ -471,14 +502,18 @@ async def run_queries(
                 raise ValueError(
                     f"Conflicting values for {name}: {existing} != {value}"
                 )
-    combined_query = "\nINTERSECT\n".join(queries)
+    if not predicates:
+        raise ValueError("No query parameters were specified.")
+    # Each predicate is an EXISTS (or direct) condition over a single ord.reaction row,
+    # ANDed together. The planner can lead with the most selective one as a semi-join
+    # and -- crucially -- stop once LIMIT rows are found, instead of materializing one
+    # SELECT DISTINCT per predicate and intersecting them.
+    where = " AND ".join(f"({predicate})" for predicate in predicates)
+    combined_query = f"SELECT reaction.reaction_id FROM ord.reaction WHERE {where}"
     if limit and ranking_query is None:
-        # LIMIT sits on top of the whole INTERSECT. Each branch is materialized
-        # (sort + unique for DISTINCT) before the set operation, so this truncates
-        # the final result rather than bounding the per-branch index scans. When
-        # ranking, the LIMIT is deferred to the scoring step so it selects the most
-        # similar matches rather than an arbitrary subset.
-        combined_query += "LIMIT %s"
+        # When ranking, the LIMIT is deferred to the scoring step so it selects the
+        # most similar matches rather than an arbitrary subset.
+        combined_query += "\nLIMIT %s"
         combined_params.append(limit)
     # Apply RDKit GUCs so the substructure/similarity operators can use their GiST
     # indexes. These are set transaction-locally (set_config local=true), so they
@@ -487,7 +522,9 @@ async def run_queries(
     for name, value in config.items():
         await cursor.execute("SELECT set_config(%s, %s, true)", (name, value))
     logger.debug((combined_query, combined_params))
-    await cursor.execute(combined_query, combined_params)
+    # The SQL text is assembled only from internal predicate fragments (all user values
+    # are bound via combined_params), so treating it as a trusted query string is safe.
+    await cursor.execute(cast(LiteralString, combined_query), combined_params)
     reaction_ids = await fetch_results(cursor)
     if ranking_query is not None:
         reaction_ids = await _rank_by_similarity(

--- a/ord_interface/api/search.py
+++ b/ord_interface/api/search.py
@@ -68,6 +68,16 @@ router = APIRouter(tags=["client"])
 BOND_LENGTH = 20
 MAX_RESULTS = 1000
 
+# Postgres statement_timeout (ms) applied to every search connection so a pathological
+# query (e.g. a common-scaffold substructure match) is cancelled and reported rather
+# than running for tens of seconds. Override with ORD_INTERFACE_STATEMENT_TIMEOUT_MS.
+STATEMENT_TIMEOUT_MS = int(os.getenv("ORD_INTERFACE_STATEMENT_TIMEOUT_MS", "20000"))
+
+QUERY_TOO_BROAD_DETAIL = (
+    "The search was too broad and timed out. Add more constraints -- for example a "
+    "yield or conversion filter, a dataset, or a more specific structure."
+)
+
 
 @asynccontextmanager
 async def get_cursor() -> AsyncIterator[AsyncCursor[dict[str, Any]]]:
@@ -85,7 +95,9 @@ async def get_cursor() -> AsyncIterator[AsyncCursor[dict[str, Any]]]:
             ),
         )
     async with await psycopg.AsyncConnection[dict[str, Any]].connect(
-        dsn, row_factory=dict_row, options="-c search_path=public,ord"
+        dsn,
+        row_factory=dict_row,
+        options=f"-c search_path=public,ord -c statement_timeout={STATEMENT_TIMEOUT_MS}",
     ) as connection:
         await connection.set_read_only(True)
         async with connection.cursor() as cursor:
@@ -168,11 +180,15 @@ async def run_query(
     limit = MAX_RESULTS
     if params.limit:
         limit = min(params.limit, MAX_RESULTS)
-    async with get_cursor() as cursor:
-        reaction_ids = await run_queries(cursor, queries, limit=limit)
-        if return_ids:
-            return reaction_ids
-        return await fetch_reactions(cursor, reaction_ids)
+    try:
+        async with get_cursor() as cursor:
+            reaction_ids = await run_queries(cursor, queries, limit=limit)
+            if return_ids:
+                return reaction_ids
+            return await fetch_reactions(cursor, reaction_ids)
+    except psycopg.errors.QueryCanceled as error:
+        # statement_timeout fired: the query was too expensive to run to completion.
+        raise HTTPException(status_code=400, detail=QUERY_TOO_BROAD_DETAIL) from error
 
 
 @router.get("/query")
@@ -262,9 +278,23 @@ async def get_search_results(inputs: ReactionIdList):
 
 
 async def run_task(task_id: str, params: QueryParams) -> bool:
-    """Wraps run_query() as a background task."""
-    # NOTE(skearnes): Use reaction IDs to avoid stuffing full protos into the result database.
-    result = await run_query(params, return_ids=True)
+    """Wraps run_query() as a background task.
+
+    A failed query (e.g. a statement_timeout mapped to an HTTPException) is recorded
+    under ``error:{task_id}`` so ``fetch_query_result`` can report it instead of
+    leaving the task pending forever.
+    """
+    try:
+        # NOTE(skearnes): Use reaction IDs to avoid stuffing full protos into the result database.
+        result = await run_query(params, return_ids=True)
+    except HTTPException as error:
+        logger.info(f"Task {task_id} failed: {error.detail}")
+        async with get_redis() as client:
+            return await client.set(
+                f"error:{task_id}",
+                json.dumps({"status_code": error.status_code, "detail": error.detail}),
+                ex=60 * 60,
+            )
     logger.debug(f"Finished task {task_id}")
     async with get_redis() as client:
         return await client.set(f"result:{task_id}", json.dumps(result), ex=60 * 60)
@@ -291,7 +321,11 @@ async def fetch_query_result(task_id: str):
             return Response(
                 f"Task {task_id} does not exist", status_code=status.HTTP_404_NOT_FOUND
             )
+        error = await client.get(f"error:{task_id}")
         result = await client.get(f"result:{task_id}")
+    if error is not None:
+        failure = json.loads(error)
+        return Response(failure["detail"], status_code=failure["status_code"])
     if result is None:
         return Response(
             f"Task {task_id} is pending", status_code=status.HTTP_202_ACCEPTED

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -196,11 +196,15 @@ async def test_run_query_timeout_maps_to_400(monkeypatch):
     monkeypatch.setattr(search, "get_cursor", _dummy_cursor)
 
     async def cancel(*args, **kwargs):
-        raise psycopg.errors.QueryCanceled("canceling statement due to statement timeout")
+        raise psycopg.errors.QueryCanceled(
+            "canceling statement due to statement timeout"
+        )
 
     monkeypatch.setattr(search, "run_queries", cancel)
     with pytest.raises(HTTPException) as excinfo:
-        await run_query(QueryParams(component=["c1ccccc1;input;substructure"]), return_ids=True)
+        await run_query(
+            QueryParams(component=["c1ccccc1;input;substructure"]), return_ids=True
+        )
     assert excinfo.value.status_code == 400
 
 

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -15,13 +15,18 @@
 """Tests for ord_interface.api.search."""
 
 import gzip
+from contextlib import asynccontextmanager
 
+import psycopg
 import pytest
+from fastapi import HTTPException
 from ord_schema.proto import dataset_pb2
 from rdkit import Chem
 from tenacity import retry, stop_after_attempt, wait_fixed
 
+from ord_interface.api import search
 from ord_interface.api.queries import QueryResult
+from ord_interface.api.search import QueryParams, run_query, run_task
 
 QUERY_PARAMS = [
     # Single factor queries.
@@ -177,3 +182,47 @@ def test_get_product_stats(test_client):
     response.raise_for_status()
     product_stats = response.json()
     assert len(product_stats) == 10
+
+
+@asynccontextmanager
+async def _dummy_cursor():
+    yield None
+
+
+@pytest.mark.asyncio
+async def test_run_query_timeout_maps_to_400(monkeypatch):
+    # A statement_timeout surfaces as psycopg QueryCanceled; the endpoint should
+    # translate it into a graceful 400 rather than letting it become a 500.
+    monkeypatch.setattr(search, "get_cursor", _dummy_cursor)
+
+    async def cancel(*args, **kwargs):
+        raise psycopg.errors.QueryCanceled("canceling statement due to statement timeout")
+
+    monkeypatch.setattr(search, "run_queries", cancel)
+    with pytest.raises(HTTPException) as excinfo:
+        await run_query(QueryParams(component=["c1ccccc1;input;substructure"]), return_ids=True)
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_run_task_records_error(monkeypatch):
+    stored = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None):
+            stored[key] = value
+            return True
+
+    @asynccontextmanager
+    async def fake_redis():
+        yield FakeRedis()
+
+    async def fail(params, return_ids):
+        raise HTTPException(status_code=400, detail="too broad")
+
+    monkeypatch.setattr(search, "get_redis", fake_redis)
+    monkeypatch.setattr(search, "run_query", fail)
+    await run_task("task-1", QueryParams(component=["c1ccccc1;input;substructure"]))
+    assert "error:task-1" in stored
+    assert "result:task-1" not in stored
+    assert '"status_code": 400' in stored["error:task-1"]


### PR DESCRIPTION
Addresses the slow/hanging structural searches analyzed in the ord-logbook entry *"Structural search performance in the ORD interface"* (`2026-06-26-structural-search-performance.md`). Independent of the natural-language work (#203/#204); this touches the shared `queries.py`/`search.py` engine used by both `/search` and `/ask`.

## 1. Most-selective-first query shape (`queries.py`)

Previously each predicate produced a `SELECT DISTINCT reaction_id FROM …` branch, combined with `INTERSECT`, with `LIMIT` on top. Each branch was fully materialized (sort + unique) before the set operation, so `LIMIT` could **not** bound the per-branch index scans.

Now each `ReactionQuery` exposes `where_predicate` — an `EXISTS (…)` (or direct) condition correlated to a single outer `ord.reaction` row — and `run_queries` builds:

```sql
SELECT reaction.reaction_id FROM ord.reaction WHERE (p1) AND (p2) … LIMIT n
```

The planner can lead with the most selective predicate as a semi-join and **stop once `LIMIT` rows are found**. Measured against the live DB:

| query | before | after |
|---|---|---|
| benzene EXACT input + yield > 70% | ~25 s | **~10 s** |
| morphine SIMILAR product | ~22 s | **~1 s** |

(Similarity ranking is unchanged: candidates are collected, then scored/limited.)

## 2. `statement_timeout` floor (`search.py`)

`get_cursor` now sets `statement_timeout` (default **20 s**, override `ORD_INTERFACE_STATEMENT_TIMEOUT_MS`) so genuinely pathological queries — a common-scaffold substructure with no selective co-filter, or a broad match with an empty result that can't early-terminate — are cancelled rather than running for 30–80 s. The resulting `psycopg.errors.QueryCanceled` maps to a **400** with an actionable "too broad — add constraints" message. The background-task path (`run_task`/`fetch_query_result`) records the error so a timed-out async search reports it instead of polling forever. Verified on the live DB: pyridine substructure now returns a 400 at ~20 s instead of hanging.

## Tests

- All existing result-count tests (`queries_test.py`, `search_test.py`, sync + async) pass unchanged — the rewrite is result-preserving.
- Added unit tests for the `QueryCanceled → 400` mapping and the background-task error path.

## Notes

Fix #2 is the safety net; fix #1 is the real speedup where results exist. Remaining ideas for later (selectivity heuristics to reject lone broad substructure searches, SIMILAR threshold tuning, warm-cache/storage) are captured in the logbook entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restructures the reaction search engine to eliminate expensive `SELECT DISTINCT … INTERSECT` query shapes in favour of a single `SELECT … WHERE (EXISTS …) AND (EXISTS …)` with an outer `LIMIT`, enabling the Postgres planner to lead with the most-selective predicate and stop early. A `statement_timeout` floor (default 20 s, env-overridable) is added to every DB connection, with `QueryCanceled` mapped to a 400 with an actionable user message; the background-task path (`run_task`/`fetch_query_result`) now stores the error in Redis so polling callers get a meaningful response instead of waiting indefinitely.

- **`queries.py`**: Abstract method renamed from `query_and_parameters` to `where_predicate`; each subclass now returns a correlated `EXISTS (…)` fragment; `run_queries` builds one `FROM ord.reaction WHERE (p1) AND (p2) … LIMIT n` query from the collected predicates.
- **`search.py`**: `get_cursor` sets `statement_timeout`; `run_query` catches `psycopg.errors.QueryCanceled` and raises a 400; `run_task` catches `HTTPException` and writes `error:{task_id}` to Redis; `fetch_query_result` checks that key before the result key.
- **`search_test.py`**: Two new async unit tests cover the `QueryCanceled → 400` path and the background-task error-recording path using monkeypatching.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge. The SQL rewrite is semantically equivalent to the original — all user values remain bound parameters, and the query shape change is well-reasoned and consistent across all seven query subclasses.

The SQL restructuring from INTERSECT-of-DISTINCT branches to a single correlated-EXISTS WHERE clause is correct across every subclass, existing result-count tests pass unchanged, the new timeout path is covered by two unit tests, and the error-propagation through the background-task pipeline is logically sound. No new defects were identified beyond the items already noted in prior review rounds.

No files require special attention. The `_mols_source` / `_mols_join` split in `queries.py` is worth a quick read if unfamiliar, but the logic is clearly commented and used correctly.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_interface/api/queries.py | Core query refactor: `where_predicate` replaces `query_and_parameters` across all seven subclasses; new `_mols_source` property provides a correlated FROM list for EXISTS subqueries while `_mols_join` is retained for the top-level similarity-scoring query. SQL assembly is safe — user values remain bound parameters. |
| ord_interface/api/search.py | Adds `statement_timeout` to every DB connection and correctly maps `QueryCanceled` to HTTP 400. Background-task error path is newly handled: `run_task` catches `HTTPException`, stores `error:{task_id}` in Redis, and returns early before writing the result key. |
| ord_interface/api/search_test.py | Two new async unit tests cover the `QueryCanceled → 400` path and the background-task error-recording path using monkeypatching. Tests are well-scoped and deterministic. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP GET /query or /submit_query] --> B[run_query]
    B --> C{build queries list}
    C --> D[get_cursor - statement_timeout=20s]
    D --> E[run_queries]
    E --> F{collect where_predicate per ReactionQuery}
    F --> G[SELECT reaction_id FROM ord.reaction WHERE p1 AND p2 LIMIT n]
    G -->|success| H{similarity ranking?}
    H -->|no| I[return reaction_ids]
    H -->|yes| J[_rank_by_similarity top-k by Tanimoto]
    J --> I
    G -->|QueryCanceled| K[raise HTTPException 400]
    B --> L{background task?}
    L -->|yes - run_task| M[try run_query]
    M -->|success| N[Redis SET result:task_id]
    M -->|HTTPException| O[Redis SET error:task_id]
    P[GET /fetch_query_result] --> Q{Redis EXISTS query:task_id}
    Q -->|no| R[404]
    Q -->|yes| S{error:task_id?}
    S -->|yes| T[return 400 + detail]
    S -->|no| U{result:task_id?}
    U -->|no| V[202 pending]
    U -->|yes| W[fetch_reactions - return results]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[HTTP GET /query or /submit_query] --> B[run_query]
    B --> C{build queries list}
    C --> D[get_cursor - statement_timeout=20s]
    D --> E[run_queries]
    E --> F{collect where_predicate per ReactionQuery}
    F --> G[SELECT reaction_id FROM ord.reaction WHERE p1 AND p2 LIMIT n]
    G -->|success| H{similarity ranking?}
    H -->|no| I[return reaction_ids]
    H -->|yes| J[_rank_by_similarity top-k by Tanimoto]
    J --> I
    G -->|QueryCanceled| K[raise HTTPException 400]
    B --> L{background task?}
    L -->|yes - run_task| M[try run_query]
    M -->|success| N[Redis SET result:task_id]
    M -->|HTTPException| O[Redis SET error:task_id]
    P[GET /fetch_query_result] --> Q{Redis EXISTS query:task_id}
    Q -->|no| R[404]
    Q -->|yes| S{error:task_id?}
    S -->|yes| T[return 400 + detail]
    S -->|no| U{result:task_id?}
    U -->|no| V[202 pending]
    U -->|yes| W[fetch_reactions - return results]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ord_interface/api/search.py`, line 82-104 ([link](https://github.com/open-reaction-database/ord-interface/blob/6bf3f8cfa6db3344ce227b3a675ae0ffe2e0a8e2/ord_interface/api/search.py#L82-L104)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`statement_timeout` applies to all connections, not just search**

   `get_cursor()` is called by several non-search endpoints — `get_reaction`, `get_reactions`, `get_datasets`, `get_dataset`, `fetch_query_result` (via `fetch_reactions`), `input_stats`, and `product_stats` — that do not wrap their usage in `try/except psycopg.errors.QueryCanceled`. If any of those queries somehow exceed 20 s (e.g., the `input_stats` aggregation under heavy DB load), they will surface as an unhandled `QueryCanceled` that FastAPI turns into a 500 Internal Server Error — not the graceful 400 with the user-friendly message. The PR description says "applied to every search connection" but the implementation is broader. In practice this is unlikely to matter, but a separate cursor factory (or a targeted try/except at each non-search site) would keep the intended scope explicit.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Apply ruff format to search\_test.py"](https://github.com/open-reaction-database/ord-interface/commit/e863d251a6fee93be7f5e867f09abd3b7c1b7b21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40243403)</sub>

<!-- /greptile_comment -->