### PR TITLE
Encode component search predicates as JSON instead of ";"-delimited strings

### DIFF
--- a/app/src/views/search/MainSearch.tsx
+++ b/app/src/views/search/MainSearch.tsx
@@ -78,7 +78,11 @@ const MainSearch: React.FC = () => {
       options.reagent.reagents.forEach(reagent => {
         searchParams.append(
           'component',
-          `${reagent.smileSmart};${reagent.source};${reagent.matchMode.toLowerCase()}`,
+          JSON.stringify({
+            pattern: reagent.smileSmart,
+            target: reagent.source,
+            mode: reagent.matchMode.toLowerCase(),
+          }),
         );
       });
       searchParams.set(

--- a/app/src/views/search/SearchOptions.tsx
+++ b/app/src/views/search/SearchOptions.tsx
@@ -177,12 +177,16 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
       const components = Array.isArray(q.component) ? q.component : [q.component];
 
       components.forEach((comp: string) => {
-        const compArray = comp.split(';');
-        const compType = compArray[1] === 'input' ? 'reactants' : 'products';
-        const matchMode = compArray[2] || 'exact';
+        const parsed = JSON.parse(comp) as {
+          pattern: string;
+          target: string;
+          mode?: string;
+        };
+        const compType = parsed.target === 'input' ? 'reactants' : 'products';
+        const matchMode = parsed.mode || 'exact';
         const component: ReagentComponent = {
-          smileSmart: compArray[0].replaceAll('%3D', '='),
-          source: compArray[1],
+          smileSmart: parsed.pattern,
+          source: parsed.target,
           matchMode,
         };
 

--- a/app/src/views/search/SearchOptions.tsx
+++ b/app/src/views/search/SearchOptions.tsx
@@ -27,6 +27,30 @@ interface ReagentComponent {
   matchMode?: string;
 }
 
+interface ParsedComponent {
+  pattern: string;
+  target: string;
+  mode?: string;
+}
+
+/**
+ * Parses a `component` query-parameter value.
+ *
+ * New values are JSON objects; the legacy `pattern;target;mode` form is still accepted
+ * so previously shared search URLs keep working. The legacy parse splits from the right
+ * because a SMARTS pattern may itself contain `;`.
+ */
+const parseComponent = (comp: string): ParsedComponent => {
+  try {
+    return JSON.parse(comp) as ParsedComponent;
+  } catch {
+    const parts = comp.split(';');
+    const mode = parts.pop();
+    const target = parts.pop() ?? 'input';
+    return { pattern: parts.join(';'), target, mode };
+  }
+};
+
 interface ReagentOptions {
   reactants: ReagentComponent[];
   products: ReagentComponent[];
@@ -177,11 +201,7 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({ onSearchOptions }) => {
       const components = Array.isArray(q.component) ? q.component : [q.component];
 
       components.forEach((comp: string) => {
-        const parsed = JSON.parse(comp) as {
-          pattern: string;
-          target: string;
-          mode?: string;
-        };
+        const parsed = parseComponent(comp);
         const compType = parsed.target === 'input' ? 'reactants' : 'products';
         const matchMode = parsed.mode || 'exact';
         const component: ReagentComponent = {

--- a/app/src/views/search/SearchOptions.tsx
+++ b/app/src/views/search/SearchOptions.tsx
@@ -41,13 +41,26 @@ interface ParsedComponent {
  * because a SMARTS pattern may itself contain `;`.
  */
 const parseComponent = (comp: string): ParsedComponent => {
-  try {
-    return JSON.parse(comp) as ParsedComponent;
-  } catch {
+  const parseLegacy = (): ParsedComponent => {
     const parts = comp.split(';');
     const mode = parts.pop();
     const target = parts.pop() ?? 'input';
     return { pattern: parts.join(';'), target, mode };
+  };
+  try {
+    const parsed = JSON.parse(comp) as unknown;
+    // JSON.parse succeeds for null/numbers/etc.; require the component shape.
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      typeof (parsed as ParsedComponent).pattern === 'string' &&
+      typeof (parsed as ParsedComponent).target === 'string'
+    ) {
+      return parsed as ParsedComponent;
+    }
+    return parseLegacy();
+  } catch {
+    return parseLegacy();
   }
 };
 

--- a/ord_interface/api/search.py
+++ b/ord_interface/api/search.py
@@ -122,10 +122,24 @@ class QueryParams:
     min_yield: float | None = None
     max_yield: float | None = None
     doi: list[str] | None = Query(None)
+    # Each value is a JSON-encoded ComponentSpec; see ComponentSpec.
     component: list[str] | None = Query(None)
     use_stereochemistry: bool | None = None
     similarity: float | None = None
     limit: int | None = None
+
+
+class ComponentSpec(BaseModel):
+    """A single component predicate, JSON-encoded in each ``component`` query value.
+
+    Replaces a legacy ``"pattern;target;mode"`` string whose ``;`` delimiter collided
+    with SMARTS patterns (which use ``;`` as a low-precedence AND). ``target`` and
+    ``mode`` are matched case-insensitively against the ReactionComponentQuery enums.
+    """
+
+    pattern: str
+    target: str
+    mode: str
 
 
 async def run_query(
@@ -154,12 +168,12 @@ async def run_query(
         if params.similarity is not None:
             kwargs["similarity_threshold"] = params.similarity
         for spec in params.component:
-            pattern, target_name, mode_name = spec.split(";")
+            component = ComponentSpec.model_validate_json(spec)
             queries.append(
                 ReactionComponentQuery(
-                    pattern,
-                    ReactionComponentQuery.Target[target_name.upper()],
-                    ReactionComponentQuery.MatchMode[mode_name.upper()],
+                    component.pattern,
+                    ReactionComponentQuery.Target[component.target.upper()],
+                    ReactionComponentQuery.MatchMode[component.mode.upper()],
                     **kwargs,
                 )
             )

--- a/ord_interface/api/search.py
+++ b/ord_interface/api/search.py
@@ -141,6 +141,29 @@ class ComponentSpec(BaseModel):
     target: str
     mode: str
 
+    @classmethod
+    def parse(cls, spec: str) -> ComponentSpec:
+        """Parses one ``component`` value, accepting JSON or the legacy format.
+
+        New values are JSON objects; the legacy ``"pattern;target;mode"`` form is still
+        accepted so previously shared search URLs keep working. The legacy parse splits
+        from the right because a SMARTS ``pattern`` may itself contain ``;``.
+
+        Args:
+            spec: A single ``component`` query-parameter value.
+
+        Returns:
+            The parsed ComponentSpec.
+
+        Raises:
+            ValueError: If ``spec`` is neither valid JSON nor a 3-field legacy string.
+        """
+        spec = spec.strip()
+        if spec.startswith("{"):
+            return cls.model_validate_json(spec)
+        pattern, target, mode = spec.rsplit(";", 2)
+        return cls(pattern=pattern, target=target, mode=mode)
+
 
 async def run_query(
     params: QueryParams, return_ids: bool
@@ -168,7 +191,12 @@ async def run_query(
         if params.similarity is not None:
             kwargs["similarity_threshold"] = params.similarity
         for spec in params.component:
-            component = ComponentSpec.model_validate_json(spec)
+            try:
+                component = ComponentSpec.parse(spec)
+            except ValueError as error:
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid component spec: {spec!r}"
+                ) from error
             queries.append(
                 ReactionComponentQuery(
                     component.pattern,

--- a/ord_interface/api/search.py
+++ b/ord_interface/api/search.py
@@ -191,20 +191,23 @@ async def run_query(
         if params.similarity is not None:
             kwargs["similarity_threshold"] = params.similarity
         for spec in params.component:
+            # Cover the whole predicate: a bad target/mode is a KeyError on the enum
+            # lookup and an unparseable pattern is a ValueError from the query -- both
+            # are client errors, not 500s.
             try:
                 component = ComponentSpec.parse(spec)
-            except ValueError as error:
+                queries.append(
+                    ReactionComponentQuery(
+                        component.pattern,
+                        ReactionComponentQuery.Target[component.target.upper()],
+                        ReactionComponentQuery.MatchMode[component.mode.upper()],
+                        **kwargs,
+                    )
+                )
+            except (KeyError, ValueError) as error:
                 raise HTTPException(
                     status_code=400, detail=f"Invalid component spec: {spec!r}"
                 ) from error
-            queries.append(
-                ReactionComponentQuery(
-                    component.pattern,
-                    ReactionComponentQuery.Target[component.target.upper()],
-                    ReactionComponentQuery.MatchMode[component.mode.upper()],
-                    **kwargs,
-                )
-            )
     if not queries:
         raise ValueError("No query parameters were specified.")
     limit = MAX_RESULTS

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -82,6 +82,24 @@ def test_query_smarts_with_semicolon(test_client):
     assert isinstance(response.json(), list)
 
 
+def test_query_accepts_legacy_component_format(test_client):
+    # Previously shared "pattern;target;mode" URLs still work (backward compatibility).
+    response = test_client.get(
+        "/api/query",
+        params={"component": ["[Br]C1=CC=C(C(C)=O)C=C1;input;exact"]},
+    )
+    response.raise_for_status()
+    assert len(response.json()) == 10
+
+
+def test_query_invalid_component_returns_400(test_client):
+    # A spec that is neither JSON nor a 3-field legacy string is a client error.
+    response = test_client.get(
+        "/api/query", params={"component": ["not-a-valid-spec"]}
+    )
+    assert response.status_code == 400
+
+
 def test_get_reaction(test_client):
     response = test_client.get(
         "/api/reaction", params={"reaction_id": "ord-3f67aa5592fd434d97a577988d3fd241"}

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -15,6 +15,7 @@
 """Tests for ord_interface.api.search."""
 
 import gzip
+import json
 
 import pytest
 from ord_schema.proto import dataset_pb2
@@ -22,6 +23,12 @@ from rdkit import Chem
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from ord_interface.api.queries import QueryResult
+
+
+def _spec(pattern: str, target: str, mode: str) -> str:
+    """Returns a JSON-encoded component spec for the `component` query parameter."""
+    return json.dumps({"pattern": pattern, "target": target, "mode": mode})
+
 
 QUERY_PARAMS = [
     # Single factor queries.
@@ -31,26 +38,26 @@ QUERY_PARAMS = [
     ({"min_conversion": 50, "max_conversion": 90}, 7),
     ({"min_yield": 50, "max_yield": 90}, 51),
     ({"doi": ["10.1126/science.1255525"]}, 24),
-    ({"component": ["[Br]C1=CC=C(C(C)=O)C=C1;input;exact"]}, 10),
-    ({"component": ["C;input;substructure"]}, 144),
+    ({"component": [_spec("[Br]C1=CC=C(C(C)=O)C=C1", "input", "exact")]}, 10),
+    ({"component": [_spec("C", "input", "substructure")]}, 144),
     (
         {
-            "component": ["O[C@@H]1C[C@H](O)C1;input;substructure"],
+            "component": [_spec("O[C@@H]1C[C@H](O)C1", "input", "substructure")],
             "use_stereochemistry": True,
         },
         20,
     ),
-    ({"component": ["[#6];input;smarts"]}, 144),
-    ({"component": ["CC=O;input;similar"], "similarity": 0.5}, 0),
-    ({"component": ["CC=O;input;similar"], "similarity": 0.05}, 120),
+    ({"component": [_spec("[#6]", "input", "smarts")]}, 144),
+    ({"component": [_spec("CC=O", "input", "similar")], "similarity": 0.5}, 0),
+    ({"component": [_spec("CC=O", "input", "similar")], "similarity": 0.05}, 120),
     # Multi-factor queries.
     (
         {
             "min_yield": 50,
             "max_yield": 90,
             "component": [
-                "[Br]C1=CC=C(C(C)=O)C=C1;input;exact",
-                "CC(C)(C)OC(=O)NC;input;substructure",
+                _spec("[Br]C1=CC=C(C(C)=O)C=C1", "input", "exact"),
+                _spec("CC(C)(C)OC(=O)NC", "input", "substructure"),
             ],
         },
         7,
@@ -63,6 +70,16 @@ def test_query(test_client, params, num_expected):
     response = test_client.get("/api/query", params=params)
     response.raise_for_status()
     assert len(response.json()) == num_expected
+
+
+def test_query_smarts_with_semicolon(test_client):
+    # SMARTS uses ";" as a low-precedence AND; JSON-encoding the component spec means
+    # such patterns parse cleanly (the legacy ";"-delimited format split incorrectly).
+    response = test_client.get(
+        "/api/query", params={"component": [_spec("[#6;R]", "input", "smarts")]}
+    )
+    response.raise_for_status()
+    assert isinstance(response.json(), list)
 
 
 def test_get_reaction(test_client):

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -94,9 +94,7 @@ def test_query_accepts_legacy_component_format(test_client):
 
 def test_query_invalid_component_returns_400(test_client):
     # A spec that is neither JSON nor a 3-field legacy string is a client error.
-    response = test_client.get(
-        "/api/query", params={"component": ["not-a-valid-spec"]}
-    )
+    response = test_client.get("/api/query", params={"component": ["not-a-valid-spec"]})
     assert response.status_code == 400
 
 

--- a/ord_interface/api/search_test.py
+++ b/ord_interface/api/search_test.py
@@ -98,6 +98,14 @@ def test_query_invalid_component_returns_400(test_client):
     assert response.status_code == 400
 
 
+def test_query_invalid_mode_returns_400(test_client):
+    # Valid JSON but an unknown match mode (enum KeyError) is still a client error.
+    response = test_client.get(
+        "/api/query", params={"component": [_spec("C", "input", "bogus")]}
+    )
+    assert response.status_code == 400
+
+
 def test_get_reaction(test_client):
     response = test_client.get(
         "/api/reaction", params={"reaction_id": "ord-3f67aa5592fd434d97a577988d3fd241"}


### PR DESCRIPTION
The `component` query parameter encoded each predicate as a `"pattern;target;mode"` string. That delimiter collides with SMARTS, which uses `;` as a low-precedence AND — a pattern like `[#6;R]` mis-parsed and surfaced as an unhandled 500. (A right-split was a stop-gap; JSON removes the ambiguity entirely.)

## Changes

- **`search.py`**: add a `ComponentSpec` Pydantic model (`pattern`, `target`, `mode`); parse each `component` value via `ComponentSpec.parse(...)`. New values are JSON objects; **the legacy `;`-delimited form is still accepted** so previously shared search URLs keep working (right-split, since a SMARTS pattern may contain `;`). A spec that is neither JSON nor a 3-field legacy string returns a controlled **400** instead of a 500.
- **Frontend**: encode with `JSON.stringify({pattern, target, mode})` (`MainSearch.tsx`); decode with a `parseComponent()` helper (`SearchOptions.tsx`) that tries JSON and **falls back to the legacy parse** instead of throwing on `JSON.parse`. Also drops the dead `%3D` un-escaping hack — `URLSearchParams` already decodes `=`.
- **Tests**: `QUERY_PARAMS` build specs via a `_spec()` helper (JSON), plus regression tests for a `;`-containing SMARTS, a legacy-format URL (backward compat), and an invalid spec → 400.

Search stays a shareable GET request; only the per-component encoding changed (now a JSON object string), and old URLs continue to resolve.

## Verification

- Backend: `search_test.py` 39 pass; `ruff check`, `ruff format --check`, and `ty` clean.
- Frontend: `tsc -b` and `eslint` clean. (URL round-trip not exercised end-to-end against a running app — worth a quick manual smoke test of the /search page, including an old `;`-format URL.)

## Coordination

`main` has no `nl_query.py`, so this PR leaves the natural-language path (#203) alone. #203 builds the same predicate string; once this merges and #203 rebases, `build_query_params` gets a one-line change to emit a JSON `ComponentSpec`. Flagging so the merge order is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes component search predicates to use JSON query values. The main changes are:

- JSON encoding for component specs in the search URL.
- Frontend parsing for both JSON specs and old semicolon-based URLs.
- Backend parsing for both JSON specs and old semicolon-based requests.
- Controlled bad-request responses for invalid component specs.
- Tests for semicolon SMARTS patterns, legacy URLs, and malformed specs.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/views/search/MainSearch.tsx | Component search options are encoded as JSON objects before being added to the query string. |
| app/src/views/search/SearchOptions.tsx | Component query values are parsed from JSON with a legacy semicolon fallback. |
| ord_interface/api/search.py | Component specs are parsed from JSON or legacy strings, and invalid component predicates return bad-request errors. |
| ord_interface/api/search_test.py | Tests cover JSON component specs, semicolon-containing SMARTS, legacy component values, and invalid component inputs. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Map all malformed component specs to 400..."](https://github.com/open-reaction-database/ord-interface/commit/9761ba6d4b5a5dfff63c266056166b286da8b482) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40314314)</sub>

<!-- /greptile_comment -->