### PR TITLE
Expand JS test coverage to the whole React app

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -20,6 +20,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.3",
@@ -27,12 +30,71 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
+        "jsdom": "^29.1.1",
         "prettier": "^3.4.2",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.44.0",
         "vite": "^7.3.5",
         "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -288,6 +350,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -334,6 +406,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -911,6 +1136,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1754,6 +1997,107 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2556,6 +2900,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -2574,6 +2929,16 @@
       "version": "2.0.1",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2601,6 +2966,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2773,6 +3148,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -3118,6 +3514,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -3134,6 +3544,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -3146,6 +3563,16 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "license": "Apache-2.0",
@@ -3154,12 +3581,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.376",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
       "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
@@ -3544,6 +3992,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "license": "MIT",
@@ -3589,6 +4050,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "license": "ISC",
@@ -3614,6 +4085,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3648,6 +4126,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3740,6 +4269,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3748,6 +4288,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3879,6 +4436,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -3967,6 +4537,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -3995,6 +4595,14 @@
       "peerDependencies": {
         "react": "^19.2.6"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-range": {
       "version": "1.10.0",
@@ -4063,6 +4671,30 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -4151,6 +4783,19 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4221,6 +4866,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "dev": true,
@@ -4242,6 +4900,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4283,6 +4948,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4345,6 +5056,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4551,6 +5272,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -4589,6 +5358,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
-        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.13",
@@ -2019,9 +2019,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
-      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2033,12 +2033,9 @@
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=22",
+        "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=10 <11"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
-    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.13",

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",
@@ -33,6 +36,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
+    "jsdom": "^29.1.1",
     "prettier": "^3.4.2",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+
+// Every route is reachable from a plain URL, so the router is exercised by
+// pushing the path onto jsdom's history before rendering.
+const renderAt = (path: string) => {
+  window.history.pushState({}, '', path);
+  return render(<App />);
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => new Promise<Response>(() => {})),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.history.pushState({}, '', '/');
+});
+
+describe('App', () => {
+  it('frames every page with the nav and the footer', () => {
+    renderAt('/');
+    expect(screen.getByRole('link', { name: 'Browse' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'GitHub' })).toBeInTheDocument();
+  });
+
+  it('routes / to the home page', () => {
+    const { container } = renderAt('/');
+    expect(container.querySelector('.home')).toBeInTheDocument();
+  });
+
+  it('routes /about to the about page', () => {
+    renderAt('/about');
+    expect(
+      screen.getByRole('heading', { name: 'About', level: 3 }),
+    ).toBeInTheDocument();
+  });
+
+  it('routes /search to the search page', () => {
+    renderAt('/search');
+    expect(screen.getByText(/Enter search criteria/)).toBeInTheDocument();
+  });
+
+  it('routes /ask to the natural-language search page', () => {
+    renderAt('/ask');
+    expect(
+      screen.getByRole('heading', { name: 'Ask about reactions' }),
+    ).toBeInTheDocument();
+  });
+
+  it('routes /browse to the dataset list', () => {
+    const { container } = renderAt('/browse');
+    expect(container.querySelector('#browse-main')).toBeInTheDocument();
+  });
+
+  it('routes /selected-set to the reaction set', () => {
+    const { container } = renderAt('/selected-set?reaction_id=ord-1');
+    expect(container.querySelector('#selected-set-main')).toBeInTheDocument();
+  });
+
+  it('routes /dataset/:datasetId to the dataset view', () => {
+    renderAt('/dataset/ord_dataset-1');
+    expect(screen.getByRole('heading', { name: 'Dataset View' })).toBeInTheDocument();
+  });
+
+  it('routes /id/:reactionId to the reaction view', () => {
+    const { container } = renderAt('/id/ord-1');
+    expect(container.querySelector('.main-reaction-view')).toBeInTheDocument();
+  });
+
+  it('renders no page content for an unknown route', () => {
+    const { container } = renderAt('/nope');
+    expect(screen.getByRole('link', { name: 'Browse' })).toBeInTheDocument();
+    expect(container.querySelector('.home')).toBeNull();
+  });
+});

--- a/app/src/components/CopyButton.test.tsx
+++ b/app/src/components/CopyButton.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import CopyButton from './CopyButton';
+
+// userEvent.setup() installs its own navigator.clipboard stub, so spy on that
+// rather than replacing the clipboard ourselves.
+const setup = () => {
+  const user = userEvent.setup();
+  return { user, writeText: vi.spyOn(navigator.clipboard, 'writeText') };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('CopyButton', () => {
+  it('copies the text to the clipboard', async () => {
+    const { user, writeText } = setup();
+    render(<CopyButton textToCopy="CC(=O)O" />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(writeText).toHaveBeenCalledWith('CC(=O)O');
+    await expect(navigator.clipboard.readText()).resolves.toBe('CC(=O)O');
+  });
+
+  it('confirms the copy, then withdraws the confirmation', async () => {
+    const { user } = setup();
+    render(<CopyButton textToCopy="CC(=O)O" />);
+
+    await user.click(screen.getByRole('button'));
+    expect(await screen.findByText('Copied to clipboard!')).toBeInTheDocument();
+
+    await waitFor(
+      () => expect(screen.queryByText('Copied to clipboard!')).not.toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+
+  it('shows the default icon and no caption', () => {
+    render(<CopyButton textToCopy="CC(=O)O" />);
+    expect(screen.getByText('content_copy')).toBeInTheDocument();
+    expect(screen.getByRole('button').querySelector('.copy')).toBeNull();
+  });
+
+  it('shows a custom icon and caption', () => {
+    render(
+      <CopyButton
+        textToCopy="CC(=O)O"
+        icon="share"
+        buttonText="Shareable Link"
+      />,
+    );
+    expect(screen.getByText('share')).toBeInTheDocument();
+    expect(screen.getByText('Shareable Link')).toBeInTheDocument();
+  });
+
+  // A denied clipboard permission must not claim the copy succeeded.
+  it('does not confirm when the clipboard write fails', async () => {
+    const { user, writeText } = setup();
+    writeText.mockRejectedValue(new Error('denied'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<CopyButton textToCopy="CC(=O)O" />);
+
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(screen.queryByText('Copied to clipboard!')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/DownloadResults.test.tsx
+++ b/app/src/components/DownloadResults.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import DownloadResults from './DownloadResults';
+
+interface SentRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+const sent: SentRequest[] = [];
+
+// Minimal stand-in for the XMLHttpRequest the component uses to stream the
+// .pb.gz back; the tests assert on what it was asked to send.
+class FakeXHR {
+  static instances: FakeXHR[] = [];
+  onload: (() => void) | null = null;
+  responseType = '';
+  response: unknown = null;
+  status = 200;
+  private request: SentRequest = { method: '', url: '', headers: {}, body: '' };
+
+  constructor() {
+    FakeXHR.instances.push(this);
+  }
+
+  open(method: string, url: string) {
+    this.request.method = method;
+    this.request.url = url;
+  }
+
+  setRequestHeader(name: string, value: string) {
+    this.request.headers[name] = value;
+  }
+
+  send(body: string) {
+    this.request.body = body;
+    sent.push(this.request);
+  }
+}
+
+const clickedLinks: HTMLAnchorElement[] = [];
+
+beforeEach(() => {
+  sent.length = 0;
+  clickedLinks.length = 0;
+  FakeXHR.instances.length = 0;
+  vi.stubGlobal('XMLHttpRequest', FakeXHR);
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:results'),
+    revokeObjectURL: vi.fn(),
+  });
+  // jsdom does not navigate, and an un-stubbed click on a download anchor logs
+  // a "not implemented" error.
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    clickedLinks.push(this);
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const renderDownload = (reactionIds = ['ord-1', 'ord-2'], show = true) => {
+  const onHideDownloadResults = vi.fn();
+  render(
+    <DownloadResults
+      reactionIds={reactionIds}
+      showDownloadResults={show}
+      onHideDownloadResults={onHideDownloadResults}
+    />,
+  );
+  return { onHideDownloadResults };
+};
+
+describe('DownloadResults', () => {
+  it('renders nothing while hidden', () => {
+    const { container } = render(
+      <DownloadResults
+        reactionIds={['ord-1']}
+        showDownloadResults={false}
+        onHideDownloadResults={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('defaults to pb.gz', () => {
+    renderDownload();
+    expect(screen.getByLabelText('File type:')).toHaveValue('pb.gz');
+    expect(
+      screen.getByRole('button', { name: 'Download pb.gz file' }),
+    ).toBeInTheDocument();
+  });
+
+  it('restores the previously chosen file type', () => {
+    localStorage.setItem('downloadFileType', 'csv');
+    renderDownload();
+    expect(screen.getByLabelText('File type:')).toHaveValue('csv');
+  });
+
+  it('remembers a newly chosen file type', async () => {
+    const user = userEvent.setup();
+    renderDownload();
+
+    // The other formats are not implemented yet, so drive the select directly
+    // rather than through its disabled options.
+    await user.selectOptions(screen.getByLabelText('File type:'), [
+      screen.getByRole('option', { name: 'pb.gz' }),
+    ]);
+
+    expect(localStorage.getItem('downloadFileType')).toBe('pb.gz');
+  });
+
+  it('offers only pb.gz for now', () => {
+    renderDownload();
+    expect(screen.getByRole('option', { name: 'pb.gz' })).toBeEnabled();
+    expect(screen.getByRole('option', { name: /csv/ })).toBeDisabled();
+    expect(screen.getByRole('option', { name: /pbtxt/ })).toBeDisabled();
+  });
+
+  it('posts the reaction ids to the download endpoint', async () => {
+    const user = userEvent.setup();
+    renderDownload(['ord-1', 'ord-2']);
+
+    await user.click(screen.getByRole('button', { name: /Download/ }));
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].method).toBe('POST');
+    expect(sent[0].url).toBe('/api/download_search_results');
+    expect(sent[0].headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(sent[0].body)).toEqual({ reaction_ids: ['ord-1', 'ord-2'] });
+  });
+
+  it('saves the response under a .pb.gz filename', async () => {
+    const user = userEvent.setup();
+    renderDownload();
+
+    await user.click(screen.getByRole('button', { name: /Download/ }));
+    const xhr = FakeXHR.instances[0];
+    xhr.response = new Blob(['data']);
+    xhr.onload?.();
+
+    expect(clickedLinks).toHaveLength(1);
+    expect(clickedLinks[0].download).toBe('ord_search_results.pb.gz');
+    expect(clickedLinks[0].href).toContain('blob:results');
+  });
+
+  it('does not save anything when the download fails', async () => {
+    const user = userEvent.setup();
+    renderDownload();
+
+    await user.click(screen.getByRole('button', { name: /Download/ }));
+    const xhr = FakeXHR.instances[0];
+    xhr.status = 500;
+    xhr.onload?.();
+
+    expect(clickedLinks).toHaveLength(0);
+  });
+
+  it('closes on the modal close control', async () => {
+    const user = userEvent.setup();
+    const { onHideDownloadResults } = renderDownload();
+
+    await user.click(screen.getByText('✕'));
+
+    expect(onHideDownloadResults).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/EntityTable.test.tsx
+++ b/app/src/components/EntityTable.test.tsx
@@ -212,9 +212,9 @@ describe('EntityTable', () => {
     expect(visibleIds()).toEqual(['a']);
   });
 
-  it('follows a change of data', () => {
-    const { rerender } = render(
-      <EntityTable<Row> tableData={rows(2)}>
+  describe('replacement data', () => {
+    const table = (tableData: Row[]) => (
+      <EntityTable<Row> tableData={tableData}>
         {entities => (
           <ul>
             {entities.map(entity => (
@@ -222,21 +222,51 @@ describe('EntityTable', () => {
             ))}
           </ul>
         )}
-      </EntityTable>,
+      </EntityTable>
     );
-    expect(visibleIds()).toHaveLength(2);
 
-    rerender(
-      <EntityTable<Row> tableData={rows(5)}>
-        {entities => (
-          <ul>
-            {entities.map(entity => (
-              <li key={entity.id}>{entity.id}</li>
-            ))}
-          </ul>
-        )}
-      </EntityTable>,
-    );
-    expect(visibleIds()).toHaveLength(5);
+    it('follows a change of data', () => {
+      const { rerender } = render(table(rows(2)));
+      expect(visibleIds()).toHaveLength(2);
+
+      rerender(table(rows(5)));
+      expect(visibleIds()).toHaveLength(5);
+    });
+
+    // A new search can return fewer rows than the page the user is sitting on,
+    // which would otherwise slice past the end and render a blank table.
+    it('pulls the page back into range when the data shrinks', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(table(rows(25)));
+
+      await user.click(screen.getByText('Last'));
+      expect(visibleIds()[0]).toBe('row-20');
+
+      rerender(table(rows(12)));
+      expect(visibleIds()).toEqual(['row-10', 'row-11']);
+    });
+
+    it('drops to the first page when the data shrinks to a single page', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(table(rows(25)));
+
+      await user.click(screen.getByText('Last'));
+      rerender(table(rows(3)));
+
+      expect(visibleIds()).toEqual(['row-0', 'row-1', 'row-2']);
+    });
+
+    // Callers are free to rebuild `tableData` on every render; that must not
+    // drag the user back to the first page.
+    it('stays put when the replacement data is no shorter', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(table(rows(25)));
+
+      await user.click(screen.getByText('Next'));
+      expect(visibleIds()[0]).toBe('row-10');
+
+      rerender(table(rows(25)));
+      expect(visibleIds()[0]).toBe('row-10');
+    });
   });
 });

--- a/app/src/components/EntityTable.test.tsx
+++ b/app/src/components/EntityTable.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import EntityTable from './EntityTable';
+
+interface Row {
+  id: string;
+  name: string;
+  organization?: string | null;
+}
+
+const rows = (count: number): Row[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `row-${i}`,
+    name: `Name ${i}`,
+  }));
+
+const renderTable = (props: Partial<React.ComponentProps<typeof EntityTable<Row>>>) =>
+  render(
+    <EntityTable<Row>
+      tableData={[]}
+      {...props}
+    >
+      {entities => (
+        <ul>
+          {entities.map(entity => (
+            <li key={entity.id}>{entity.id}</li>
+          ))}
+        </ul>
+      )}
+    </EntityTable>,
+  );
+
+// The ids the render prop was handed on the current page.
+const visibleIds = (): string[] =>
+  screen.queryAllByRole('listitem').map(item => item.textContent ?? '');
+
+describe('EntityTable', () => {
+  it('renders nothing without data', () => {
+    const { container } = renderTable({ tableData: [] });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the title', () => {
+    renderTable({ tableData: rows(1), title: 'Search Results' });
+    expect(screen.getByText('Search Results')).toBeInTheDocument();
+  });
+
+  it('shows the search box by default and hides it on request', () => {
+    const { unmount } = renderTable({ tableData: rows(1) });
+    expect(screen.getByLabelText('Search:')).toBeInTheDocument();
+    unmount();
+
+    renderTable({ tableData: rows(1), displaySearch: false });
+    expect(screen.queryByLabelText('Search:')).not.toBeInTheDocument();
+  });
+
+  it('hands the render prop only the first page', () => {
+    renderTable({ tableData: rows(25) });
+    expect(visibleIds()).toEqual(rows(10).map(row => row.id));
+    expect(screen.getByText(/of 25 entries/)).toBeInTheDocument();
+  });
+
+  it('paginates forward and back', async () => {
+    const user = userEvent.setup();
+    renderTable({ tableData: rows(25) });
+
+    await user.click(screen.getByText('Next'));
+    expect(visibleIds()[0]).toBe('row-10');
+
+    await user.click(screen.getByText('Last'));
+    expect(visibleIds()).toEqual(['row-20', 'row-21', 'row-22', 'row-23', 'row-24']);
+
+    await user.click(screen.getByText('First'));
+    expect(visibleIds()[0]).toBe('row-0');
+  });
+
+  // "Next" and "Previous" wrap around; the numbered links next to the current
+  // page do not.
+  it('wraps around at the ends', async () => {
+    const user = userEvent.setup();
+    renderTable({ tableData: rows(25) });
+
+    await user.click(screen.getByText('Previous'));
+    expect(visibleIds()[0]).toBe('row-20');
+
+    await user.click(screen.getByText('Next'));
+    expect(visibleIds()[0]).toBe('row-0');
+  });
+
+  it('resizes the page and returns to the first page', async () => {
+    const user = userEvent.setup();
+    renderTable({ tableData: rows(25) });
+
+    await user.click(screen.getByText('Last'));
+    expect(visibleIds()[0]).toBe('row-20');
+
+    await user.selectOptions(screen.getByRole('combobox'), '25');
+    expect(visibleIds()).toHaveLength(25);
+  });
+
+  // Filtering from a later page used to leave the user on a page number past
+  // the end of the narrowed results, showing an empty list.
+  it('returns to the first page when the filter changes', async () => {
+    const user = userEvent.setup();
+    renderTable({ tableData: rows(25) });
+
+    await user.click(screen.getByText('Last'));
+    expect(visibleIds()[0]).toBe('row-20');
+
+    await user.type(screen.getByLabelText('Search:'), 'row-1');
+    expect(visibleIds()).toEqual([
+      'row-1',
+      'row-10',
+      'row-11',
+      'row-12',
+      'row-13',
+      'row-14',
+      'row-15',
+      'row-16',
+      'row-17',
+      'row-18',
+    ]);
+  });
+
+  it('returns to the first page when the filter is cleared', async () => {
+    const user = userEvent.setup();
+    renderTable({ tableData: rows(25) });
+
+    await user.type(screen.getByLabelText('Search:'), 'row-1');
+    await user.click(screen.getByText('Last'));
+    expect(visibleIds()).toEqual(['row-19']);
+
+    await user.clear(screen.getByLabelText('Search:'));
+    expect(visibleIds()[0]).toBe('row-0');
+  });
+
+  it('filters on any field, case-insensitively', async () => {
+    const user = userEvent.setup();
+    renderTable({
+      tableData: [
+        { id: 'a', name: 'Suzuki', organization: 'MIT' },
+        { id: 'b', name: 'Heck', organization: 'Stanford' },
+      ],
+    });
+
+    await user.type(screen.getByLabelText('Search:'), 'suzuki');
+    expect(visibleIds()).toEqual(['a']);
+
+    await user.clear(screen.getByLabelText('Search:'));
+    await user.type(screen.getByLabelText('Search:'), 'stanford');
+    expect(visibleIds()).toEqual(['b']);
+  });
+
+  // Terms are ANDed: every whitespace-separated term must match some field.
+  it('requires every search term to match', async () => {
+    const user = userEvent.setup();
+    renderTable({
+      tableData: [
+        { id: 'a', name: 'Suzuki', organization: 'MIT' },
+        { id: 'b', name: 'Suzuki', organization: 'Stanford' },
+      ],
+    });
+
+    await user.type(screen.getByLabelText('Search:'), 'suzuki mit');
+    expect(visibleIds()).toEqual(['a']);
+  });
+
+  it('ignores extra whitespace between terms', async () => {
+    const user = userEvent.setup();
+    renderTable({ tableData: rows(3) });
+
+    await user.type(screen.getByLabelText('Search:'), '  row-1   ');
+    expect(visibleIds()).toEqual(['row-1']);
+  });
+
+  it('reports an empty result set rather than falling back to everything', async () => {
+    const user = userEvent.setup();
+    renderTable({ tableData: rows(3) });
+
+    await user.type(screen.getByLabelText('Search:'), 'no-such-row');
+    expect(visibleIds()).toEqual([]);
+    expect(screen.getByText(/of 0 entries/)).toBeInTheDocument();
+  });
+
+  it('matches an absent field as the literal "null"', async () => {
+    const user = userEvent.setup();
+    renderTable({
+      tableData: [
+        { id: 'a', name: 'Suzuki', organization: null },
+        { id: 'b', name: 'Heck', organization: 'Stanford' },
+      ],
+    });
+
+    await user.type(screen.getByLabelText('Search:'), 'null');
+    expect(visibleIds()).toEqual(['a']);
+  });
+
+  it('follows a change of data', () => {
+    const { rerender } = render(
+      <EntityTable<Row> tableData={rows(2)}>
+        {entities => (
+          <ul>
+            {entities.map(entity => (
+              <li key={entity.id}>{entity.id}</li>
+            ))}
+          </ul>
+        )}
+      </EntityTable>,
+    );
+    expect(visibleIds()).toHaveLength(2);
+
+    rerender(
+      <EntityTable<Row> tableData={rows(5)}>
+        {entities => (
+          <ul>
+            {entities.map(entity => (
+              <li key={entity.id}>{entity.id}</li>
+            ))}
+          </ul>
+        )}
+      </EntityTable>,
+    );
+    expect(visibleIds()).toHaveLength(5);
+  });
+});

--- a/app/src/components/EntityTable.tsx
+++ b/app/src/components/EntityTable.tsx
@@ -96,6 +96,15 @@ function EntityTable<T>({
     return 1;
   }, [pagination, filteredEntities]);
 
+  // Shorter data can arrive under the page the user is on — a new search, or a
+  // dataset with fewer rows. Keeping the old page number would slice past the
+  // end and render a blank table. Depending on `lastPage` rather than on the
+  // data itself keeps this immune to callers that build `tableData` inline: it
+  // is a number, so a re-render with an equal-length array is not a change.
+  useEffect(() => {
+    setCurrentPage(page => Math.min(page, lastPage));
+  }, [lastPage]);
+
   const pagiPrev = useMemo(() => {
     return currentPage === 1 ? lastPage : currentPage - 1;
   }, [currentPage, lastPage]);

--- a/app/src/components/EntityTable.tsx
+++ b/app/src/components/EntityTable.tsx
@@ -39,10 +39,12 @@ function EntityTable<T>({
     setEntities(tableData);
   }, [tableData]);
 
-  // Reset to first page when pagination changes
+  // Reset to the first page whenever the page size or the filter changes; the
+  // current page number is meaningless against a different set of rows, and
+  // holding onto it lands the user on a blank page past the end.
   useEffect(() => {
     setCurrentPage(1);
-  }, [pagination]);
+  }, [pagination, searchString]);
 
   const searchArray = useMemo(() => {
     return searchString.split(' ').filter(term => term.trim() !== '');

--- a/app/src/components/FloatingModal.test.tsx
+++ b/app/src/components/FloatingModal.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import FloatingModal from './FloatingModal';
+
+const renderModal = (className?: string) => {
+  const onCloseModal = vi.fn();
+  const { container } = render(
+    <FloatingModal
+      title="Download Results"
+      onCloseModal={onCloseModal}
+      className={className}
+    >
+      <p>body content</p>
+    </FloatingModal>,
+  );
+  return { container, onCloseModal };
+};
+
+describe('FloatingModal', () => {
+  it('shows the title and the children', () => {
+    renderModal();
+    expect(screen.getByText('Download Results')).toBeInTheDocument();
+    expect(screen.getByText('body content')).toBeInTheDocument();
+  });
+
+  it('closes on the close control', async () => {
+    const user = userEvent.setup();
+    const { container, onCloseModal } = renderModal();
+
+    await user.click(container.querySelector('.close')!);
+
+    expect(onCloseModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on a click outside the modal', async () => {
+    const user = userEvent.setup();
+    const { container, onCloseModal } = renderModal();
+
+    await user.click(container.querySelector('.modal-background')!);
+
+    expect(onCloseModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays open on a click inside the modal', async () => {
+    const user = userEvent.setup();
+    const { onCloseModal } = renderModal();
+
+    await user.click(screen.getByText('body content'));
+
+    expect(onCloseModal).not.toHaveBeenCalled();
+  });
+
+  it('appends a caller-supplied class without dropping its own', () => {
+    const { container } = renderModal('wide');
+    expect(container.querySelector('.modal-container')).toHaveClass(
+      'modal-container',
+      'wide',
+    );
+  });
+
+  it('leaves the class list clean when no extra class is given', () => {
+    const { container } = renderModal();
+    expect(container.querySelector('.modal-container')).toHaveAttribute(
+      'class',
+      'modal-container',
+    );
+  });
+});

--- a/app/src/components/HeaderNav.test.tsx
+++ b/app/src/components/HeaderNav.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import HeaderNav from './HeaderNav';
+import MainFooter from './MainFooter';
+
+describe('HeaderNav', () => {
+  const renderNav = () =>
+    render(
+      <MemoryRouter>
+        <HeaderNav />
+      </MemoryRouter>,
+    );
+
+  it('links to the in-app pages', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: 'Browse' })).toHaveAttribute(
+      'href',
+      '/browse',
+    );
+    expect(screen.getByRole('link', { name: 'Search' })).toHaveAttribute(
+      'href',
+      '/search',
+    );
+    expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute(
+      'href',
+      '/about',
+    );
+  });
+
+  it('links out to the editor and the docs', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: 'Contribute' })).toHaveAttribute(
+      'href',
+      'https://app.open-reaction-database.org',
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
+      'href',
+      'https://docs.open-reaction-database.org',
+    );
+  });
+
+  // /ask exists but is deliberately unlisted while it is in development.
+  it('does not advertise the natural-language search', () => {
+    renderNav();
+    expect(screen.queryByRole('link', { name: /ask/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('MainFooter', () => {
+  it('links to GitHub and the docs without leaking the referrer', () => {
+    render(<MainFooter />);
+
+    const github = screen.getByRole('link', { name: 'GitHub' });
+    expect(github).toHaveAttribute('href', 'https://github.com/Open-Reaction-Database');
+    expect(github).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(github).toHaveAttribute('target', '_blank');
+    expect(screen.getByRole('link', { name: 'Documentation' })).toHaveAttribute(
+      'href',
+      'https://docs.open-reaction-database.org',
+    );
+  });
+});

--- a/app/src/components/ModalKetcher.test.tsx
+++ b/app/src/components/ModalKetcher.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ModalKetcher from './ModalKetcher';
+
+const setMolecule = vi.fn();
+const getSmiles = vi.fn(async () => 'CC=O');
+
+// Ketcher itself never boots under jsdom, so stand in for the API the iframe
+// would eventually expose on its contentWindow.
+const exposeKetcher = (ketcher: unknown = { setMolecule, getSmiles }) => {
+  vi.spyOn(HTMLIFrameElement.prototype, 'contentWindow', 'get').mockReturnValue({
+    ketcher,
+  } as unknown as Window);
+};
+
+const renderModal = (smiles = 'CCO') => {
+  const onUpdateSmiles = vi.fn();
+  const onCloseModal = vi.fn();
+  const result = render(
+    <ModalKetcher
+      smiles={smiles}
+      onUpdateSmiles={onUpdateSmiles}
+      onCloseModal={onCloseModal}
+    />,
+  );
+  return { ...result, onUpdateSmiles, onCloseModal };
+};
+
+// Drives the fake clock and flushes the state updates and promise
+// continuations the elapsed timers kicked off.
+const advance = async (ms: number) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+};
+
+// The component polls the iframe once a second until Ketcher shows up.
+const waitForKetcher = async () => {
+  await advance(1000);
+  expect(screen.getByText('Save')).toBeEnabled();
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setMolecule.mockClear();
+  getSmiles.mockClear().mockResolvedValue('CC=O');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, status: 200, json: async () => 'MOLFILE' })),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('ModalKetcher', () => {
+  it('embeds the standalone Ketcher bundle', () => {
+    renderModal();
+    expect(screen.getByTitle('Ketcher Molecular Editor')).toHaveAttribute(
+      'src',
+      '/ketcher/index.html',
+    );
+  });
+
+  it('spins and blocks saving until Ketcher loads', () => {
+    const { container } = renderModal();
+    expect(container.querySelector('.modal-loading')).toBeInTheDocument();
+    expect(screen.getByText('Save')).toBeDisabled();
+  });
+
+  it('stops spinning once Ketcher appears', async () => {
+    exposeKetcher();
+    const { container } = renderModal();
+
+    await waitForKetcher();
+
+    expect(container.querySelector('.modal-loading')).toBeNull();
+  });
+
+  // Nothing is going to arrive after 30s; give up rather than spin forever.
+  it('gives up after thirty seconds', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container } = renderModal();
+
+    await advance(30_000);
+
+    expect(container.querySelector('.modal-loading')).toBeNull();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Ketcher failed to load within 30 seconds',
+    );
+  });
+
+  describe('loading the starting structure', () => {
+    it('converts the SMILES to a molfile and hands it to Ketcher', async () => {
+      exposeKetcher();
+      renderModal('CCO');
+
+      await waitForKetcher();
+
+      expect(fetch).toHaveBeenCalledWith('/api/molfile?smiles=CCO');
+      expect(setMolecule).toHaveBeenCalledWith('MOLFILE');
+    });
+
+    it('url-encodes the SMILES', async () => {
+      exposeKetcher();
+      renderModal('C/C=C/C');
+
+      await waitForKetcher();
+
+      expect(fetch).toHaveBeenCalledWith('/api/molfile?smiles=C%2FC%3DC%2FC');
+    });
+
+    it('opens an empty editor when there is no starting structure', async () => {
+      exposeKetcher();
+      renderModal('');
+
+      await waitForKetcher();
+
+      expect(fetch).not.toHaveBeenCalled();
+      expect(setMolecule).not.toHaveBeenCalled();
+    });
+
+    it('warns rather than drawing when the conversion fails', async () => {
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      exposeKetcher();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({ ok: false, status: 500 })),
+      );
+      renderModal('CCO');
+
+      await waitForKetcher();
+
+      expect(consoleWarn).toHaveBeenCalled();
+      expect(setMolecule).not.toHaveBeenCalled();
+    });
+
+    it('survives a network error', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      exposeKetcher();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => Promise.reject(new Error('offline'))),
+      );
+      renderModal('CCO');
+
+      await waitForKetcher();
+
+      expect(consoleError).toHaveBeenCalled();
+    });
+  });
+
+  describe('saving', () => {
+    it('reports the drawn structure and closes', async () => {
+      exposeKetcher();
+      const { onUpdateSmiles, onCloseModal } = renderModal();
+      await waitForKetcher();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Save'));
+      });
+
+      expect(onUpdateSmiles).toHaveBeenCalledWith('CC=O');
+      expect(onCloseModal).toHaveBeenCalled();
+    });
+
+    it('stays open when Ketcher cannot produce a SMILES', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      getSmiles.mockRejectedValue(new Error('no structure'));
+      exposeKetcher();
+      const { onUpdateSmiles, onCloseModal } = renderModal();
+      await waitForKetcher();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Save'));
+      });
+
+      expect(consoleError).toHaveBeenCalled();
+      expect(onUpdateSmiles).not.toHaveBeenCalled();
+      expect(onCloseModal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dismissing', () => {
+    it('closes on Cancel', () => {
+      const { onCloseModal } = renderModal();
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(onCloseModal).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes on a click outside the editor', () => {
+      const { container, onCloseModal } = renderModal();
+      fireEvent.click(container.querySelector('.background')!);
+      expect(onCloseModal).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays open on a click inside the editor', () => {
+      const { container, onCloseModal } = renderModal();
+      fireEvent.click(container.querySelector('#ketcher_modal')!);
+      expect(onCloseModal).not.toHaveBeenCalled();
+    });
+
+    it('closes on Escape', () => {
+      const { onCloseModal } = renderModal();
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onCloseModal).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores other keys', () => {
+      const { onCloseModal } = renderModal();
+      fireEvent.keyDown(document, { key: 'Enter' });
+      expect(onCloseModal).not.toHaveBeenCalled();
+    });
+
+    // The listeners and the poll must not outlive the modal.
+    it('stops polling once unmounted', async () => {
+      exposeKetcher();
+      const { unmount, onCloseModal } = renderModal();
+
+      unmount();
+      await advance(30_000);
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onCloseModal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/src/components/ReactionCard.test.tsx
+++ b/app/src/components/ReactionCard.test.tsx
@@ -1,0 +1,306 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ReactionCard from './ReactionCard';
+import type { ReactionData, SearchResult } from '../types/search';
+
+const reaction = (data: unknown = {}): SearchResult => ({
+  reaction_id: 'ord-1',
+  dataset_id: 'ord_dataset-1',
+  proto: '',
+  data: data as ReactionData,
+});
+
+const renderCard = (result: SearchResult, props = {}) =>
+  render(
+    <MemoryRouter initialEntries={['/search']}>
+      <Routes>
+        <Route
+          path="/search"
+          element={
+            <ReactionCard
+              reaction={result}
+              {...props}
+            />
+          }
+        />
+        <Route
+          path="/id/:id"
+          element={<div>reaction detail page</div>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, status: 200, text: async () => '<b>A + B</b>' })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('ReactionCard', () => {
+  describe('yield and conversion', () => {
+    it('shows the yield measurement', async () => {
+      renderCard(
+        reaction({
+          outcomesList: [
+            {
+              productsList: [
+                { measurementsList: [{ type: 3, percentage: { value: 82.35 } }] },
+              ],
+            },
+          ],
+        }),
+      );
+      expect(await screen.findByText('Yield: 82.4%')).toBeInTheDocument();
+    });
+
+    // Only measurements of type YIELD count; the rest are purity, area, etc.
+    it('ignores measurements that are not yields', async () => {
+      renderCard(
+        reaction({
+          outcomesList: [
+            {
+              productsList: [
+                { measurementsList: [{ type: 5, percentage: { value: 99 } }] },
+              ],
+            },
+          ],
+        }),
+      );
+      expect(await screen.findByText('Yield: Not listed')).toBeInTheDocument();
+    });
+
+    it('shows the conversion', async () => {
+      renderCard(
+        reaction({ outcomesList: [{ conversion: { value: 50, precision: 5 } }] }),
+      );
+      expect(await screen.findByText('Conversion: 50% ± 5')).toBeInTheDocument();
+    });
+
+    it('says so when neither was recorded', async () => {
+      renderCard(reaction());
+      expect(await screen.findByText('Yield: Not listed')).toBeInTheDocument();
+      expect(screen.getByText('Conversion: Not listed')).toBeInTheDocument();
+    });
+  });
+
+  describe('conditions', () => {
+    it('joins temperature, pressure and duration', async () => {
+      renderCard(
+        reaction({
+          conditions: {
+            temperature: { setpoint: { value: 25, units: 1 } },
+            pressure: { setpoint: { value: 1, units: 2 } },
+          },
+          outcomesList: [{ reactionTime: { value: 12, units: 1 } }],
+        }),
+      );
+      expect(
+        await screen.findByText(
+          'Conditions: at 25 celsius; under 1 atmosphere; for 12 hour',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to default units when the enum is unrecognized', async () => {
+      renderCard(
+        reaction({
+          conditions: {
+            temperature: { setpoint: { value: 25, units: 99 } },
+            pressure: { setpoint: { value: 1, units: 99 } },
+          },
+          outcomesList: [{ reactionTime: { value: 12, units: 99 } }],
+        }),
+      );
+      expect(
+        await screen.findByText('Conditions: at 25°C; under 1 atm; for 12s'),
+      ).toBeInTheDocument();
+    });
+
+    it('says so when none were recorded', async () => {
+      renderCard(reaction());
+      expect(await screen.findByText('Conditions: Not Listed')).toBeInTheDocument();
+    });
+  });
+
+  describe('product identity', () => {
+    it('labels the identifier with its type', async () => {
+      renderCard(
+        reaction({
+          outcomesList: [
+            { productsList: [{ identifiersList: [{ type: 2, value: 'CCO' }] }] },
+          ],
+        }),
+      );
+      expect(await screen.findByText('Product SMILES: CCO')).toBeInTheDocument();
+    });
+
+    it('omits the product row when there is no identifier', async () => {
+      renderCard(reaction());
+      await screen.findByText('Yield: Not listed');
+      expect(screen.queryByText(/^Product /)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('provenance', () => {
+    it('shows the uploader, date, DOI and publication link', async () => {
+      renderCard(
+        reaction({
+          provenance: {
+            doi: '10.1021/jacs.8b01523',
+            publicationUrl: 'https://example.com/paper',
+            recordCreated: {
+              person: { name: 'Ada Lovelace', organization: 'ORD' },
+              time: { value: '2021-05-04T00:00:00Z' },
+            },
+          },
+        }),
+      );
+
+      expect(
+        await screen.findByText('Uploaded by Ada Lovelace, ORD'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('DOI: 10.1021/jacs.8b01523')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Publication URL' })).toHaveAttribute(
+        'href',
+        'https://example.com/paper',
+      );
+    });
+
+    it('falls back to "Unknown" for a missing uploader', async () => {
+      renderCard(reaction());
+      expect(
+        await screen.findByText('Uploaded by Unknown, Unknown'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Uploaded on Unknown')).toBeInTheDocument();
+      expect(screen.getByText('DOI: Not available')).toBeInTheDocument();
+    });
+
+    it('omits the publication link when there is no URL', async () => {
+      renderCard(reaction());
+      await screen.findByText('DOI: Not available');
+      expect(
+        screen.queryByRole('link', { name: 'Publication URL' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('badges a mined record', async () => {
+      renderCard(reaction({ provenance: { isMined: true } }));
+      expect(await screen.findByText('Mined')).toBeInTheDocument();
+    });
+
+    it('leaves an unmined record unbadged', async () => {
+      renderCard(reaction({ provenance: { isMined: false } }));
+      await screen.findByText('DOI: Not available');
+      expect(screen.queryByText('Mined')).not.toBeInTheDocument();
+    });
+  });
+
+  it('links back to the parent dataset', async () => {
+    renderCard(reaction());
+    expect(await screen.findByRole('link', { name: 'ord_dataset-1' })).toHaveAttribute(
+      'href',
+      '/search?dataset_id=ord_dataset-1&limit=100',
+    );
+  });
+
+  describe('the reaction summary', () => {
+    it('renders the HTML the API returns', async () => {
+      const { container } = renderCard(reaction());
+      await waitFor(() =>
+        expect(container.querySelector('.reaction-table')?.innerHTML).toContain(
+          '<b>A + B</b>',
+        ),
+      );
+      expect(fetch).toHaveBeenCalledWith('/api/reaction_summary?reaction_id=ord-1');
+    });
+
+    // The 4xx/5xx body is an HTML error page, which would otherwise be injected
+    // into every card on the results list.
+    it('does not render an error page', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const text = vi.fn(async () => '<h1>500 Internal Server Error</h1>');
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({ ok: false, status: 500, text })),
+      );
+
+      const { container } = renderCard(reaction());
+
+      await waitFor(() => expect(consoleError).toHaveBeenCalled());
+      expect(text).not.toHaveBeenCalled();
+      expect(container.querySelector('.reaction-table')?.innerHTML).not.toContain(
+        '500 Internal Server Error',
+      );
+    });
+
+    it('survives a network error', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => Promise.reject(new Error('offline'))),
+      );
+
+      renderCard(reaction());
+
+      await waitFor(() => expect(consoleError).toHaveBeenCalled());
+      expect(screen.getByText('Yield: Not listed')).toBeInTheDocument();
+    });
+  });
+
+  describe('selection', () => {
+    it('reports being checked and unchecked', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      renderCard(reaction(), { onSelectionChange, isSelected: false });
+
+      await user.click(await screen.findByLabelText('Select reaction'));
+
+      expect(onSelectionChange).toHaveBeenCalledWith('ord-1', true);
+    });
+
+    it('reflects the selected state it was given', async () => {
+      renderCard(reaction(), { isSelected: true, onSelectionChange: vi.fn() });
+      expect(await screen.findByLabelText('Select reaction')).toBeChecked();
+    });
+
+    it('hides the checkbox when the card is not selectable', async () => {
+      renderCard(reaction(), { isSelectable: false });
+      await screen.findByText('Yield: Not listed');
+      expect(screen.queryByLabelText('Select reaction')).not.toBeInTheDocument();
+    });
+  });
+
+  it('navigates to the detail page', async () => {
+    const user = userEvent.setup();
+    renderCard(reaction());
+
+    await user.click(await screen.findByRole('button', { name: 'View Full Details' }));
+
+    expect(screen.getByText('reaction detail page')).toBeInTheDocument();
+  });
+});

--- a/app/src/hooks/useNLQuery.test.ts
+++ b/app/src/hooks/useNLQuery.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import reaction_pb from 'ord-schema';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { NLQueryResponse } from '../types/search';
+import { useNLQuery } from './useNLQuery';
+
+const encodedReaction = (reactionId: string): string => {
+  const reaction = new reaction_pb.Reaction();
+  reaction.setReactionId(reactionId);
+  return btoa(String.fromCharCode(...reaction.serializeBinary()));
+};
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(
+    QueryClientProvider,
+    {
+      client: new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      }),
+    },
+    children,
+  );
+
+const response = (overrides: Partial<NLQueryResponse> = {}): NLQueryResponse => ({
+  query: 'suzuki couplings with high yield',
+  interpretation: { components: [], min_yield: 80 },
+  resolved_components: [
+    {
+      identifier: 'phenylboronic acid',
+      smiles: 'OB(O)c1ccccc1',
+      resolver: 'pubchem',
+      target: 'INPUT',
+      mode: 'EXACT',
+    },
+  ],
+  query_components: ['{"pattern":"OB(O)c1ccccc1","target":"input","mode":"exact"}'],
+  results: [{ reaction_id: 'ord-1', proto: encodedReaction('ord-1') }],
+  dry_run: false,
+  ...overrides,
+});
+
+const stubFetch = (body: NLQueryResponse, status = 200) => {
+  const fetchMock = vi.fn(
+    async () =>
+      ({ ok: status < 400, status, json: async () => body }) as unknown as Response,
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const renderNLQuery = (query: string | null, enabled = true, dryRun = false) =>
+  renderHook(() => useNLQuery(query, enabled, dryRun), { wrapper });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useNLQuery', () => {
+  it('stays idle when disabled', () => {
+    const fetchMock = stubFetch(response());
+    renderNLQuery('suzuki couplings', false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('stays idle without a question', () => {
+    const fetchMock = stubFetch(response());
+    renderNLQuery(null);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // A box the user has only typed spaces into is not a question.
+  it('stays idle for a blank question', () => {
+    const fetchMock = stubFetch(response());
+    renderNLQuery('   ');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('url-encodes the question', async () => {
+    const fetchMock = stubFetch(response());
+    const { result } = renderNLQuery('yield > 80% & Pd');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/nl_query?q=yield%20%3E%2080%25%20%26%20Pd',
+      undefined,
+    );
+  });
+
+  it('asks for a dry run when requested', async () => {
+    const fetchMock = stubFetch(response({ dry_run: true }));
+    const { result } = renderNLQuery('suzuki couplings', true, true);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/nl_query?q=suzuki%20couplings&dry_run=true',
+      undefined,
+    );
+    expect(result.current.data?.dryRun).toBe(true);
+  });
+
+  it('renames the payload fields for the view layer', async () => {
+    const payload = response();
+    stubFetch(payload);
+    const { result } = renderNLQuery('suzuki couplings');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.interpretation).toEqual(payload.interpretation);
+    expect(result.current.data?.resolvedComponents).toEqual(
+      payload.resolved_components,
+    );
+    expect(result.current.data?.queryComponents).toEqual(payload.query_components);
+    expect(result.current.data?.dryRun).toBe(false);
+  });
+
+  it('deserializes the result protos', async () => {
+    stubFetch(response());
+    const { result } = renderNLQuery('suzuki couplings');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.results).toEqual([
+      expect.objectContaining({
+        reaction_id: 'ord-1',
+        data: expect.objectContaining({ reactionId: 'ord-1' }),
+      }),
+    ]);
+  });
+
+  it('surfaces a failed request', async () => {
+    stubFetch(response(), 500);
+    const { result } = renderNLQuery('suzuki couplings');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('nl_query failed (HTTP 500)');
+  });
+
+  // Dry runs and real runs are cached separately, so toggling the switch
+  // re-queries instead of replaying the other mode's answer.
+  it('re-queries when the dry-run flag changes', async () => {
+    const fetchMock = stubFetch(response());
+    const { result, rerender } = renderHook(
+      ({ dryRun }: { dryRun: boolean }) => useNLQuery('suzuki couplings', true, dryRun),
+      { wrapper, initialProps: { dryRun: false } },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    rerender({ dryRun: true });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/app/src/hooks/useSearchTask.test.ts
+++ b/app/src/hooks/useSearchTask.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import reaction_pb from 'ord-schema';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useSearchTask } from './useSearchTask';
+
+// A serialized Reaction, base64-encoded the way the API returns it.
+const encodedReaction = (reactionId: string): string => {
+  const reaction = new reaction_pb.Reaction();
+  reaction.setReactionId(reactionId);
+  return btoa(String.fromCharCode(...reaction.serializeBinary()));
+};
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(
+    QueryClientProvider,
+    {
+      client: new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      }),
+    },
+    children,
+  );
+
+const renderSearchTask = (queryString: string | null, enabled = true) =>
+  renderHook(() => useSearchTask(queryString, enabled), { wrapper });
+
+const jsonResponse = (body: unknown, status = 200) =>
+  ({ ok: status < 400, status, json: async () => body }) as Response;
+
+// Stubs the two-step protocol: submit_query hands back a task id, and
+// fetch_query_result replays the given statuses in order.
+const stubProtocol = (
+  results: Array<{ status: number; body?: unknown }>,
+  taskId = 'task-1',
+) => {
+  let poll = 0;
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.startsWith('/api/submit_query')) return jsonResponse(taskId);
+    const next = results[Math.min(poll, results.length - 1)];
+    poll += 1;
+    return jsonResponse(next.body ?? [], next.status);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const submitCalls = (fetchMock: ReturnType<typeof vi.fn>): string[] =>
+  fetchMock.mock.calls
+    .map(call => call[0] as string)
+    .filter(url => url.startsWith('/api/submit_query'));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useSearchTask', () => {
+  it('stays idle when disabled', () => {
+    const fetchMock = stubProtocol([{ status: 200 }]);
+    renderSearchTask('?dataset_id=ord_dataset-1', false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('stays idle without a query string', () => {
+    const fetchMock = stubProtocol([{ status: 200 }]);
+    renderSearchTask(null);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('submits the query string verbatim', async () => {
+    const fetchMock = stubProtocol([{ status: 200 }]);
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(submitCalls(fetchMock)).toEqual([
+      '/api/submit_query?dataset_id=ord_dataset-1',
+    ]);
+  });
+
+  it('polls the task id returned by submit_query', async () => {
+    const fetchMock = stubProtocol([{ status: 200 }], 'task-42');
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledWith('/api/fetch_query_result?task_id=task-42');
+  });
+
+  it('deserializes the result protos', async () => {
+    stubProtocol([
+      {
+        status: 200,
+        body: [
+          {
+            reaction_id: 'ord-1',
+            dataset_id: 'ord_dataset-1',
+            proto: encodedReaction('ord-1'),
+          },
+        ],
+      },
+    ]);
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({
+      status: 'success',
+      results: [
+        expect.objectContaining({
+          reaction_id: 'ord-1',
+          dataset_id: 'ord_dataset-1',
+          data: expect.objectContaining({ reactionId: 'ord-1' }),
+        }),
+      ],
+    });
+  });
+
+  it('reports pending while the task is still running', async () => {
+    stubProtocol([{ status: 202 }]);
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual({ status: 'pending', taskId: 'task-1' }),
+    );
+  });
+
+  it('keeps polling until the task completes', async () => {
+    stubProtocol([
+      { status: 202 },
+      { status: 202 },
+      {
+        status: 200,
+        body: [{ reaction_id: 'ord-1', proto: encodedReaction('ord-1') }],
+      },
+    ]);
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() => expect(result.current.data?.status).toBe('success'), {
+      timeout: 5000,
+    });
+  });
+
+  // Submitting twice would leave an orphaned task running on the backend.
+  it('submits only once across the whole poll cycle', async () => {
+    const fetchMock = stubProtocol([{ status: 202 }, { status: 202 }, { status: 200 }]);
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() => expect(result.current.data?.status).toBe('success'), {
+      timeout: 5000,
+    });
+    expect(submitCalls(fetchMock)).toHaveLength(1);
+  });
+
+  it('surfaces a failed submit', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({}, 500)),
+    );
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('submit_query failed (HTTP 500)');
+  });
+
+  it('surfaces a failed poll', async () => {
+    stubProtocol([{ status: 500 }], 'task-7');
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Search task task-7 failed (HTTP 500)');
+  });
+
+  it('gives up on a task that runs past the timeout', async () => {
+    let now = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.startsWith('/api/submit_query')) {
+          // The clock passes the deadline while the submit is in flight.
+          now = 200_000;
+          return jsonResponse('task-9');
+        }
+        return jsonResponse([], 200);
+      }),
+    );
+    const { result } = renderSearchTask('?dataset_id=ord_dataset-1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe(
+      'Search task task-9 timed out after 120s',
+    );
+  });
+
+  it('starts a fresh task when the query string changes', async () => {
+    const fetchMock = stubProtocol([{ status: 200 }]);
+    const { result, rerender } = renderHook(
+      ({ query }: { query: string }) => useSearchTask(query, true),
+      { wrapper, initialProps: { query: '?dataset_id=ord_dataset-1' } },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    rerender({ query: '?dataset_id=ord_dataset-2' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(submitCalls(fetchMock)).toEqual([
+      '/api/submit_query?dataset_id=ord_dataset-1',
+      '/api/submit_query?dataset_id=ord_dataset-2',
+    ]);
+  });
+});

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Node exposes an experimental `localStorage` global that evaluates to
+// undefined unless the process was started with --localstorage-file, and it
+// shadows the one jsdom installs on the test environment's window. Components
+// that persist selections and preferences need a working Storage, so provide
+// one.
+const memoryStorage = (): Storage => {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    key: (index: number) => [...entries.keys()][index] ?? null,
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      entries.set(String(key), String(value));
+    },
+    removeItem: (key: string) => {
+      entries.delete(key);
+    },
+    clear: () => {
+      entries.clear();
+    },
+  };
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: memoryStorage(),
+  configurable: true,
+  writable: true,
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});

--- a/app/src/utils/amount.test.ts
+++ b/app/src/utils/amount.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Amount } from 'ord-schema/proto/reaction_pb';
+import { describe, expect, it } from 'vitest';
+import { amountObj, amountStr } from './amount';
+
+// Only the oneof field under test is populated, and some cases carry a unit
+// value outside the generated enum, so the fields are cast rather than typed.
+const amount = (fields: unknown): Amount.AsObject => fields as Amount.AsObject;
+
+describe('amountObj', () => {
+  it('reports no category without an amount', () => {
+    expect(amountObj(undefined)).toEqual({ unitCategory: '' });
+  });
+
+  it('reports no category when no oneof field is set', () => {
+    expect(amountObj(amount({}))).toEqual({ unitCategory: '' });
+  });
+
+  it('normalizes moles', () => {
+    expect(
+      amountObj(amount({ moles: { value: 1.5, units: 2, precision: 0 } })),
+    ).toEqual({ unitAmount: 1.5, unitType: 'MILLIMOLE', unitCategory: 'moles' });
+  });
+
+  it('normalizes volume', () => {
+    expect(
+      amountObj(amount({ volume: { value: 10, units: 2, precision: 0 } })),
+    ).toEqual({ unitAmount: 10, unitType: 'MILLILITER', unitCategory: 'volume' });
+  });
+
+  it('normalizes mass', () => {
+    expect(amountObj(amount({ mass: { value: 250, units: 3, precision: 0 } }))).toEqual(
+      {
+        unitAmount: 250,
+        unitType: 'MILLIGRAM',
+        unitCategory: 'mass',
+      },
+    );
+  });
+
+  it('normalizes an unmeasured amount, which carries no value', () => {
+    expect(amountObj(amount({ unmeasured: { type: 1, details: '' } }))).toEqual({
+      unitCategory: 'unmeasured',
+    });
+  });
+
+  it('leaves the unit type undefined when the units are unrecognized', () => {
+    expect(amountObj(amount({ mass: { value: 1, units: 99, precision: 0 } }))).toEqual({
+      unitAmount: 1,
+      unitType: undefined,
+      unitCategory: 'mass',
+    });
+  });
+
+  it('prefers moles when more than one oneof field survived serialization', () => {
+    expect(
+      amountObj(
+        amount({
+          moles: { value: 1, units: 1, precision: 0 },
+          volume: { value: 2, units: 1, precision: 0 },
+        }),
+      ).unitCategory,
+    ).toBe('moles');
+  });
+});
+
+describe('amountStr', () => {
+  it('renders the value with a lowercase unit', () => {
+    expect(
+      amountStr({ unitAmount: 1.5, unitType: 'MILLIMOLE', unitCategory: 'moles' }),
+    ).toBe('1.5 millimole');
+  });
+
+  it('rounds to three decimals', () => {
+    expect(
+      amountStr({ unitAmount: 1.23456, unitType: 'GRAM', unitCategory: 'mass' }),
+    ).toBe('1.235 gram');
+    expect(
+      amountStr({ unitAmount: 0.0001, unitType: 'GRAM', unitCategory: 'mass' }),
+    ).toBe('0 gram');
+  });
+
+  // A zero amount is real data; only a *missing* amount renders as empty.
+  it('renders a zero amount', () => {
+    expect(amountStr({ unitAmount: 0, unitType: 'GRAM', unitCategory: 'mass' })).toBe(
+      '0 gram',
+    );
+  });
+
+  it('renders nothing without a value or a unit', () => {
+    expect(amountStr({ unitCategory: 'unmeasured' })).toBe('');
+    expect(amountStr({ unitAmount: 5, unitCategory: 'mass' })).toBe('');
+    expect(amountStr({ unitType: 'GRAM', unitCategory: 'mass' })).toBe('');
+  });
+
+  it('round-trips an Amount through both helpers', () => {
+    expect(
+      amountStr(amountObj(amount({ volume: { value: 2.5, units: 3, precision: 0 } }))),
+    ).toBe('2.5 microliter');
+  });
+});

--- a/app/src/utils/api.test.ts
+++ b/app/src/utils/api.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchJson } from './api';
+
+const mockFetch = (response: Partial<Response>) => {
+  const fetchMock = vi.fn().mockResolvedValue(response as Response);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchJson', () => {
+  it('returns the parsed body on success', async () => {
+    mockFetch({ ok: true, status: 200, json: async () => ({ hits: 3 }) });
+    await expect(fetchJson<{ hits: number }>('/api/thing')).resolves.toEqual({
+      hits: 3,
+    });
+  });
+
+  it('passes the request options through to fetch', async () => {
+    const fetchMock = mockFetch({ ok: true, status: 200, json: async () => [] });
+    const init = { method: 'POST', body: 'payload' };
+    await fetchJson('/api/thing', init);
+    expect(fetchMock).toHaveBeenCalledWith('/api/thing', init);
+  });
+
+  it('throws with the status on a non-2xx response', async () => {
+    mockFetch({ ok: false, status: 500, json: async () => ({}) });
+    await expect(fetchJson('/api/thing')).rejects.toThrow(
+      '/api/thing failed (HTTP 500)',
+    );
+  });
+
+  it('names the request by its label when one is given', async () => {
+    mockFetch({ ok: false, status: 404, json: async () => ({}) });
+    await expect(fetchJson('/api/thing', undefined, 'submit_query')).rejects.toThrow(
+      'submit_query failed (HTTP 404)',
+    );
+  });
+
+  // A URL or Request object has no useful default name, so it falls back to a
+  // generic one rather than stringifying the input.
+  it('falls back to "request" for a non-string input', async () => {
+    mockFetch({ ok: false, status: 503, json: async () => ({}) });
+    await expect(fetchJson(new URL('https://example.com/api'))).rejects.toThrow(
+      'request failed (HTTP 503)',
+    );
+  });
+
+  // A failed response body is typically an HTML error page; parsing it as JSON
+  // would throw something unhelpful instead of the status.
+  it('does not read the body of a failed response', async () => {
+    const json = vi.fn();
+    mockFetch({ ok: false, status: 500, json });
+    await expect(fetchJson('/api/thing')).rejects.toThrow();
+    expect(json).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/utils/base64.test.ts
+++ b/app/src/utils/base64.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { base64ToBytes } from './base64';
+
+const decode = (base64String: string): number[] =>
+  Array.from(new Uint8Array(base64ToBytes(base64String)));
+
+const encode = (bytes: number[]): string => btoa(String.fromCharCode(...bytes));
+
+describe('base64ToBytes', () => {
+  it('decodes to a buffer of the right length', () => {
+    const buffer = base64ToBytes(btoa('hello'));
+    expect(buffer).toBeInstanceOf(ArrayBuffer);
+    expect(buffer.byteLength).toBe(5);
+  });
+
+  it('decodes ASCII', () => {
+    expect(decode(btoa('hello'))).toEqual([104, 101, 108, 108, 111]);
+  });
+
+  it('decodes an empty string', () => {
+    expect(decode('')).toEqual([]);
+  });
+
+  // Serialized protos are arbitrary bytes, so anything that truncated to 7 bits
+  // or tripped over a NUL would corrupt every reaction on the page.
+  it('round-trips the full byte range', () => {
+    const bytes = Array.from({ length: 256 }, (_, i) => i);
+    expect(decode(encode(bytes))).toEqual(bytes);
+  });
+
+  it('decodes padded and unpadded lengths alike', () => {
+    expect(decode(encode([1]))).toEqual([1]);
+    expect(decode(encode([1, 2]))).toEqual([1, 2]);
+    expect(decode(encode([1, 2, 3]))).toEqual([1, 2, 3]);
+  });
+});

--- a/app/src/utils/conditions.test.ts
+++ b/app/src/utils/conditions.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  IlluminationConditions,
+  PressureConditions,
+  StirringConditions,
+} from 'ord-schema/proto/reaction_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  electrochemType,
+  flowType,
+  illumType,
+  lengthStr,
+  pressureAtmo,
+  pressureSetPoint,
+  pressureType,
+  stirRate,
+  stirType,
+  tempSetPoint,
+  tempType,
+} from './conditions';
+
+// The generated AsObject types narrow enum fields to their known values and
+// require every scalar, so the fixtures below are cast in rather than typed.
+// Several cases deliberately use a unit outside the enum.
+const measurement = <T>(value: number, units: number, precision = 0): T =>
+  ({ value, units, precision }) as T;
+
+const enumValue = <T>(value: number): T => value as T;
+
+const atmosphere = (
+  type: number,
+  details = '',
+): PressureConditions.Atmosphere.AsObject =>
+  ({ type, details }) as unknown as PressureConditions.Atmosphere.AsObject;
+
+const stirringRate = (type: number): StirringConditions.StirringRate.AsObject =>
+  ({
+    type,
+    details: '',
+    rpm: 0,
+  }) as unknown as StirringConditions.StirringRate.AsObject;
+
+const illumination = (type: number, details = ''): IlluminationConditions.AsObject =>
+  ({ type, details, color: '' }) as unknown as IlluminationConditions.AsObject;
+
+describe('tempType', () => {
+  it('names the control type', () => {
+    expect(tempType(2)).toBe('AMBIENT');
+    expect(tempType(6)).toBe('ICE_BATH');
+  });
+
+  it('renders an empty string when there is nothing to name', () => {
+    expect(tempType(undefined)).toBe('');
+    expect(tempType(99)).toBe('');
+  });
+});
+
+describe('tempSetPoint', () => {
+  it('renders "None" without a setpoint', () => {
+    expect(tempSetPoint(undefined)).toBe('None');
+  });
+
+  // Only the unit's first letter is shown, after the degree sign: "°C".
+  it('abbreviates the unit', () => {
+    expect(tempSetPoint(measurement(25, 1))).toBe('25 °C');
+    expect(tempSetPoint(measurement(77, 2))).toBe('77 °F');
+    expect(tempSetPoint(measurement(298, 3))).toBe('298 °K');
+  });
+
+  it('includes the precision when one was recorded', () => {
+    expect(tempSetPoint(measurement(25, 1, 2))).toBe('25 (± 2) °C');
+  });
+
+  it('omits the unit letter when the unit is unrecognized', () => {
+    expect(tempSetPoint(measurement(25, 99))).toBe('25 °');
+  });
+});
+
+describe('pressureType', () => {
+  it('names the control type', () => {
+    expect(pressureType(4)).toBe('SEALED');
+  });
+
+  it('renders an empty string when there is nothing to name', () => {
+    expect(pressureType(undefined)).toBe('');
+    expect(pressureType(99)).toBe('');
+  });
+});
+
+describe('pressureSetPoint', () => {
+  it('renders "None" without a setpoint', () => {
+    expect(pressureSetPoint(undefined)).toBe('None');
+  });
+
+  it('spells the unit out in lowercase', () => {
+    expect(pressureSetPoint(measurement(1, 2))).toBe('1 atmosphere');
+    expect(pressureSetPoint(measurement(760, 8))).toBe('760 mm_hg');
+  });
+
+  it('includes the precision when one was recorded', () => {
+    expect(pressureSetPoint(measurement(1, 1, 0.1))).toBe('1 (± 0.1) bar');
+  });
+
+  it('drops the unit when it is unrecognized', () => {
+    expect(pressureSetPoint(measurement(1, 99))).toBe('1 ');
+  });
+});
+
+describe('pressureAtmo', () => {
+  it('names the atmosphere', () => {
+    expect(pressureAtmo(atmosphere(3))).toBe('NITROGEN');
+  });
+
+  it('appends the details for a custom atmosphere', () => {
+    expect(pressureAtmo(atmosphere(1, '5% H2 in Ar'))).toBe('CUSTOM, 5% H2 in Ar');
+  });
+
+  it('renders an empty string without an atmosphere', () => {
+    expect(pressureAtmo(undefined)).toBe('');
+  });
+});
+
+describe('stirType', () => {
+  it('names the stirring method', () => {
+    expect(stirType(3)).toBe('STIR_BAR');
+  });
+
+  it('renders an empty string when there is nothing to name', () => {
+    expect(stirType(undefined)).toBe('');
+    expect(stirType(99)).toBe('');
+  });
+});
+
+describe('stirRate', () => {
+  // The rate object is passed whole; the helper reads .type off it rather than
+  // comparing the object itself to the enum values.
+  it('names the rate from the rate object', () => {
+    expect(stirRate(stirringRate(1))).toBe('HIGH');
+    expect(stirRate(stirringRate(3))).toBe('LOW');
+  });
+
+  it('renders an empty string without a rate', () => {
+    expect(stirRate(undefined)).toBe('');
+  });
+});
+
+describe('illumType', () => {
+  it('names the illumination type', () => {
+    expect(illumType(illumination(4))).toBe('LED');
+  });
+
+  it('appends the details after a colon', () => {
+    expect(illumType(illumination(4, '450 nm'))).toBe('LED: 450 nm');
+  });
+
+  it('renders an empty string without illumination', () => {
+    expect(illumType(undefined)).toBe('');
+  });
+});
+
+describe('lengthStr', () => {
+  it('renders the value with a lowercase unit', () => {
+    expect(lengthStr(measurement(5, 2))).toBe('5 millimeter');
+  });
+
+  it('drops the unit when it is unrecognized', () => {
+    expect(lengthStr(measurement(5, 99))).toBe('5');
+  });
+
+  it('returns undefined without a length', () => {
+    expect(lengthStr(undefined)).toBeUndefined();
+  });
+});
+
+describe('electrochemType', () => {
+  it('names the electrochemistry type', () => {
+    expect(electrochemType(enumValue(2))).toBe('CONSTANT_CURRENT');
+  });
+
+  it('renders an empty string when there is nothing to name', () => {
+    expect(electrochemType(undefined)).toBe('');
+    expect(electrochemType(enumValue(99))).toBe('');
+  });
+});
+
+describe('flowType', () => {
+  it('names the flow type', () => {
+    expect(flowType(enumValue(2))).toBe('PLUG_FLOW_REACTOR');
+  });
+
+  it('renders an empty string when there is nothing to name', () => {
+    expect(flowType(undefined)).toBe('');
+    expect(flowType(enumValue(99))).toBe('');
+  });
+});

--- a/app/src/utils/enum.test.ts
+++ b/app/src/utils/enum.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import reaction_pb from 'ord-schema';
+import { describe, expect, it } from 'vitest';
+import { enumName } from './enum';
+
+describe('enumName', () => {
+  it('reverse-looks-up a generated protobuf enum map', () => {
+    expect(enumName(reaction_pb.Time.TimeUnit, 1)).toBe('HOUR');
+    expect(enumName(reaction_pb.Mass.MassUnit, 2)).toBe('GRAM');
+    expect(enumName(reaction_pb.Pressure.PressureUnit, 8)).toBe('MM_HG');
+  });
+
+  // Zero is a real enum value in proto3, not a missing one.
+  it('resolves the zero value', () => {
+    expect(enumName(reaction_pb.Time.TimeUnit, 0)).toBe('UNSPECIFIED');
+  });
+
+  it('returns undefined for a value the map does not contain', () => {
+    expect(enumName(reaction_pb.Time.TimeUnit, 99)).toBeUndefined();
+    expect(enumName(reaction_pb.Time.TimeUnit, -1)).toBeUndefined();
+  });
+
+  it('returns undefined without a value', () => {
+    expect(enumName(reaction_pb.Time.TimeUnit, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for anything that is not an enum map', () => {
+    expect(enumName(null, 0)).toBeUndefined();
+    expect(enumName(undefined, 0)).toBeUndefined();
+    expect(enumName('HOUR', 0)).toBeUndefined();
+    expect(enumName(1, 1)).toBeUndefined();
+  });
+
+  // Object.entries would happily walk an array's indices, and the numeric
+  // string keys would render as garbage unit names.
+  it('matches on value, not on key type', () => {
+    expect(enumName({ A: 1, B: '1' }, 1)).toBe('A');
+    expect(enumName({ A: '1' }, 1)).toBeUndefined();
+  });
+});

--- a/app/src/utils/outcomes.test.ts
+++ b/app/src/utils/outcomes.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Percentage, Time } from 'ord-schema/proto/reaction_pb';
+import { describe, expect, it } from 'vitest';
+import { formatPercentage, formattedTime } from './outcomes';
+
+// The generated AsObject types narrow `units` to the known enum values, so the
+// unrecognized-unit cases have to be cast in.
+const time = (value: number, units: number): Time.AsObject =>
+  ({ value, units, precision: 0 }) as unknown as Time.AsObject;
+
+const percentage = (value: number, precision = 0): Percentage.AsObject => ({
+  value,
+  precision,
+});
+
+describe('formattedTime', () => {
+  it('renders nothing without a time', () => {
+    expect(formattedTime(undefined)).toBeNull();
+  });
+
+  it('renders nothing for an unrecognized unit', () => {
+    expect(formattedTime(time(3, 99))).toBeNull();
+  });
+
+  it('pluralizes the unit', () => {
+    expect(formattedTime(time(3, 1))).toBe('3 hour(s)');
+    expect(formattedTime(time(30, 2))).toBe('30 minute(s)');
+    expect(formattedTime(time(1, 4))).toBe('1 day(s)');
+  });
+
+  // "unspecified(s)" would read as nonsense, so the zero value stays singular.
+  it('leaves the unspecified unit unpluralized', () => {
+    expect(formattedTime(time(3, 0))).toBe('3 unspecified');
+  });
+});
+
+describe('formatPercentage', () => {
+  it('renders nothing without a percentage', () => {
+    expect(formatPercentage(undefined)).toBe('');
+  });
+
+  it('rounds to one decimal', () => {
+    expect(formatPercentage(percentage(82.34, 0))).toBe('82.3%');
+    expect(formatPercentage(percentage(82.35, 0))).toBe('82.4%');
+    expect(formatPercentage(percentage(100, 0))).toBe('100%');
+  });
+
+  it('renders a zero yield rather than an empty string', () => {
+    expect(formatPercentage(percentage(0, 0))).toBe('0%');
+  });
+
+  it('appends the precision when one was recorded', () => {
+    expect(formatPercentage(percentage(75, 5))).toBe('75% ± 5');
+  });
+
+  // proto3 scalars default to 0, so "± 0" would appear on every record that
+  // simply left precision unset.
+  it('treats a zero or non-finite precision as unrecorded', () => {
+    expect(formatPercentage(percentage(75, 0))).toBe('75%');
+    expect(formatPercentage(percentage(75, NaN))).toBe('75%');
+    expect(formatPercentage(percentage(75, Infinity))).toBe('75%');
+  });
+});

--- a/app/src/views/browse/MainBrowse.test.tsx
+++ b/app/src/views/browse/MainBrowse.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MainBrowse from './MainBrowse';
+
+const dataset = (overrides = {}) => ({
+  dataset_id: 'ord_dataset-1',
+  name: 'Suzuki couplings',
+  description: 'Reactions from https://doi.org/10.1021/jacs.8b01523',
+  num_reactions: 1234,
+  submitted_at: '2021-05-04',
+  ...overrides,
+});
+
+const stubDatasets = (datasets: unknown[]) => {
+  const fetchMock = vi.fn(async () => ({ json: async () => datasets }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const renderBrowse = () =>
+  render(
+    <MemoryRouter>
+      <MainBrowse />
+    </MemoryRouter>,
+  );
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('MainBrowse', () => {
+  it('requests the dataset list', async () => {
+    const fetchMock = stubDatasets([dataset()]);
+    renderBrowse();
+
+    expect(await screen.findByText('ord_dataset-1')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith('/api/datasets', { method: 'GET' });
+  });
+
+  it('shows a spinner until the datasets arrive', () => {
+    stubDatasets([dataset()]);
+    const { container } = renderBrowse();
+    expect(container.querySelector('.spinner-main')).toBeInTheDocument();
+  });
+
+  it('keeps the spinner up when the list comes back empty', async () => {
+    stubDatasets([]);
+    const { container } = renderBrowse();
+    expect(container.querySelector('.spinner-main')).toBeInTheDocument();
+  });
+
+  it('links each dataset to its detail page', async () => {
+    stubDatasets([dataset()]);
+    renderBrowse();
+
+    expect(await screen.findByRole('link', { name: 'ord_dataset-1' })).toHaveAttribute(
+      'href',
+      '/dataset/ord_dataset-1',
+    );
+  });
+
+  it('groups the reaction count', async () => {
+    stubDatasets([dataset({ num_reactions: 1234567 })]);
+    renderBrowse();
+
+    expect(await screen.findByText('1,234,567')).toBeInTheDocument();
+  });
+
+  // Names and descriptions are free text that often carries a DOI or URL.
+  it('links references in the name and description', async () => {
+    stubDatasets([dataset({ name: 'From 10.1021/jacs.8b01523' })]);
+    renderBrowse();
+
+    const links = await screen.findAllByRole('link', {
+      name: /10\.1021\/jacs\.8b01523/,
+    });
+    expect(links[0]).toHaveAttribute('href', 'https://doi.org/10.1021/jacs.8b01523');
+  });
+
+  describe('the details modal', () => {
+    it('opens with the submission date and reaction count', async () => {
+      const user = userEvent.setup();
+      stubDatasets([dataset()]);
+      renderBrowse();
+
+      await user.click(
+        await screen.findByRole('button', { name: 'Show dataset details' }),
+      );
+
+      expect(screen.getByText('Submitted:')).toBeInTheDocument();
+      expect(screen.getByText('2021-05-04')).toBeInTheDocument();
+      expect(screen.getByText('Reactions:')).toBeInTheDocument();
+      expect(screen.getAllByText('1,234')).not.toHaveLength(0);
+    });
+
+    it('shows a dash for an unknown submission date', async () => {
+      const user = userEvent.setup();
+      stubDatasets([dataset({ submitted_at: null })]);
+      renderBrowse();
+
+      await user.click(
+        await screen.findByRole('button', { name: 'Show dataset details' }),
+      );
+
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+
+    it('closes again', async () => {
+      const user = userEvent.setup();
+      stubDatasets([dataset()]);
+      renderBrowse();
+
+      await user.click(
+        await screen.findByRole('button', { name: 'Show dataset details' }),
+      );
+      await user.click(screen.getByText('✕'));
+
+      expect(screen.queryByText('Submitted:')).not.toBeInTheDocument();
+    });
+  });
+
+  it('survives a failed request', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Promise.reject(new Error('offline'))),
+    );
+
+    const { container } = renderBrowse();
+
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(container.querySelector('.spinner-main')).toBeInTheDocument();
+  });
+});

--- a/app/src/views/browse/selected-set/MainSelectedSet.test.tsx
+++ b/app/src/views/browse/selected-set/MainSelectedSet.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import reaction_pb from 'ord-schema';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MainSelectedSet from './MainSelectedSet';
+
+const encodedReaction = (reactionId: string): string => {
+  const reaction = new reaction_pb.Reaction();
+  reaction.setReactionId(reactionId);
+  return btoa(String.fromCharCode(...reaction.serializeBinary()));
+};
+
+// The bodies POSTed to /api/reactions, for the assertions below.
+const posted: RequestInit[] = [];
+
+// /api/reactions returns the set; /api/reaction_summary draws each card.
+const stubApi = (reactionIds: string[], status = 200) => {
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === '/api/reactions') {
+      posted.push(init!);
+      return {
+        ok: status < 400,
+        status,
+        json: async () =>
+          reactionIds.map(id => ({
+            reaction_id: id,
+            dataset_id: 'ord_dataset-1',
+            proto: encodedReaction(id),
+          })),
+      };
+    }
+    return { ok: true, status: 200, text: async () => '' };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const renderSet = (search: string) =>
+  render(
+    <MemoryRouter initialEntries={[`/selected-set${search}`]}>
+      <MainSelectedSet />
+    </MemoryRouter>,
+  );
+
+afterEach(() => {
+  posted.length = 0;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('MainSelectedSet', () => {
+  it('posts the reaction ids from the URL', async () => {
+    stubApi(['ord-1', 'ord-2']);
+    renderSet('?reaction_id=ord-1&reaction_id=ord-2');
+
+    expect(await screen.findByText('Reaction Set')).toBeInTheDocument();
+    expect(JSON.parse(posted[0].body as string)).toEqual({
+      reaction_ids: ['ord-1', 'ord-2'],
+    });
+  });
+
+  it('renders a card per reaction', async () => {
+    stubApi(['ord-1', 'ord-2']);
+    const { container } = renderSet('?reaction_id=ord-1&reaction_id=ord-2');
+
+    await screen.findByText('Reaction Set');
+    expect(container.querySelectorAll('.reaction-container')).toHaveLength(2);
+  });
+
+  it('offers a shareable link and a download', async () => {
+    stubApi(['ord-1']);
+    renderSet('?reaction_id=ord-1');
+
+    expect(await screen.findByText('Shareable Link')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download Reaction Set' })).toBeEnabled();
+  });
+
+  it('opens the download modal', async () => {
+    const user = userEvent.setup();
+    stubApi(['ord-1']);
+    renderSet('?reaction_id=ord-1');
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Download Reaction Set' }),
+    );
+
+    expect(screen.getByText('Download Results')).toBeInTheDocument();
+  });
+
+  // Landing here with no ids in the URL should settle on the empty state
+  // rather than spinning forever.
+  it('stops loading when the URL carries no ids', async () => {
+    const fetchMock = stubApi([]);
+    renderSet('');
+
+    expect(
+      await screen.findByText('There was an issue fetching your selected reactions.'),
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed fetch instead of an empty page', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubApi(['ord-1'], 500);
+    renderSet('?reaction_id=ord-1');
+
+    expect(
+      await screen.findByText('There was an issue fetching your selected reactions.'),
+    ).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('spins while the reactions are in flight', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    const { container } = renderSet('?reaction_id=ord-1');
+    expect(container.querySelector('.spinner-main')).toBeInTheDocument();
+  });
+});

--- a/app/src/views/dataset-view/ChartView.test.tsx
+++ b/app/src/views/dataset-view/ChartView.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ChartView from './ChartView';
+
+const CHART_DATA = [
+  { smiles: 'CCO', times_appearing: 12 },
+  { smiles: 'CC=O', times_appearing: 4 },
+];
+
+const stubApi = (
+  { stats = CHART_DATA, statsStatus = 200, svgStatus = 200 } = {} as {
+    stats?: unknown;
+    statsStatus?: number;
+    svgStatus?: number;
+  },
+) => {
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.startsWith('/api/compound_svg')) {
+      return {
+        ok: svgStatus < 400,
+        status: svgStatus,
+        json: async () => '<svg class="mol"></svg>',
+      };
+    }
+    return { ok: statsStatus < 400, status: statsStatus, json: async () => stats };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const renderChart = (props: Partial<React.ComponentProps<typeof ChartView>> = {}) =>
+  render(
+    <ChartView
+      uniqueId="reactantsFrequency"
+      title="Frequency of Reactants"
+      apiCall="input_stats"
+      role="reactant"
+      datasetId="ord_dataset-1"
+      {...props}
+    />,
+  );
+
+const bars = (container: HTMLElement) => [...container.querySelectorAll('rect')];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('ChartView', () => {
+  it('requests the stats for its dataset and endpoint', async () => {
+    const fetchMock = stubApi();
+    const { container } = renderChart();
+
+    await waitFor(() => expect(bars(container)).toHaveLength(2));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/input_stats?dataset_id=ord_dataset-1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('url-encodes the dataset id', async () => {
+    const fetchMock = stubApi();
+    renderChart({ datasetId: 'ord dataset/1' });
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/input_stats?dataset_id=ord%20dataset%2F1',
+        expect.anything(),
+      ),
+    );
+  });
+
+  it('shows the title', () => {
+    stubApi();
+    renderChart();
+    expect(screen.getByText('Frequency of Reactants')).toBeInTheDocument();
+  });
+
+  it('draws a bar per compound', async () => {
+    stubApi();
+    const { container } = renderChart();
+    await waitFor(() => expect(bars(container)).toHaveLength(2));
+  });
+
+  it('redraws at the collapsed size', async () => {
+    stubApi();
+    const { container, rerender } = renderChart({ isCollapsed: false });
+    await waitFor(() =>
+      expect(container.querySelector('svg')).toHaveAttribute('width', '400'),
+    );
+
+    rerender(
+      <ChartView
+        uniqueId="reactantsFrequency"
+        title="Frequency of Reactants"
+        apiCall="input_stats"
+        role="reactant"
+        datasetId="ord_dataset-1"
+        isCollapsed
+      />,
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector('svg')).toHaveAttribute('width', '180'),
+    );
+  });
+
+  it('reports a failed stats request', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubApi({ statsStatus: 500 });
+    renderChart();
+
+    expect(
+      await screen.findByText('Failed to load chart: input_stats failed (HTTP 500)'),
+    ).toBeInTheDocument();
+  });
+
+  it('draws nothing when the dataset has no stats', async () => {
+    stubApi({ stats: [] });
+    const { container } = renderChart();
+
+    await waitFor(() =>
+      expect(container.querySelector('.chart-view__loading')).toHaveStyle({
+        visibility: 'hidden',
+      }),
+    );
+    expect(bars(container)).toHaveLength(0);
+  });
+
+  describe('the hover tooltip', () => {
+    it('shows the count and the compound drawing', async () => {
+      stubApi();
+      const { container } = renderChart();
+      await waitFor(() => expect(bars(container)).toHaveLength(2));
+
+      fireEvent.mouseOver(bars(container)[0], { clientX: 100, clientY: 200 });
+
+      expect(await screen.findByText('Count: 12')).toBeInTheDocument();
+      await waitFor(() =>
+        expect(container.querySelector('.chart-view__svg')?.innerHTML).toBe(
+          '<svg class="mol"></svg>',
+        ),
+      );
+    });
+
+    it('hides again on mouse out', async () => {
+      stubApi();
+      const { container } = renderChart();
+      await waitFor(() => expect(bars(container)).toHaveLength(2));
+
+      fireEvent.mouseOver(bars(container)[0], { clientX: 100, clientY: 200 });
+      await screen.findByText('Count: 12');
+      fireEvent.mouseOut(bars(container)[0]);
+
+      expect(screen.queryByText('Count: 12')).not.toBeInTheDocument();
+    });
+
+    // The 4xx/5xx body is an HTML error page, not an SVG.
+    it('does not render an error page as the drawing', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      stubApi({ svgStatus: 500 });
+      const { container } = renderChart();
+      await waitFor(() => expect(bars(container)).toHaveLength(2));
+
+      fireEvent.mouseOver(bars(container)[0], { clientX: 100, clientY: 200 });
+
+      await waitFor(() => expect(consoleError).toHaveBeenCalled());
+      expect(container.querySelector('.chart-view__svg')).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/app/src/views/dataset-view/MainDatasetView.test.tsx
+++ b/app/src/views/dataset-view/MainDatasetView.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import reaction_pb from 'ord-schema';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MainDatasetView from './MainDatasetView';
+
+const encodedReaction = (reactionId: string): string => {
+  const reaction = new reaction_pb.Reaction();
+  reaction.setReactionId(reactionId);
+  return btoa(String.fromCharCode(...reaction.serializeBinary()));
+};
+
+interface ApiOverrides {
+  dataset?: { status?: number; body?: unknown };
+  reactions?: string[];
+  resultStatus?: number;
+}
+
+const stubApi = ({
+  dataset,
+  reactions = ['ord-1'],
+  resultStatus = 200,
+}: ApiOverrides) => {
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.startsWith('/api/dataset?')) {
+      const status = dataset?.status ?? 200;
+      return {
+        ok: status < 400,
+        status,
+        json: async () =>
+          dataset?.body ?? {
+            dataset_id: 'ord_dataset-1',
+            name: 'Suzuki couplings',
+            description: 'from the literature',
+            num_reactions: 500,
+          },
+      };
+    }
+    if (url.startsWith('/api/submit_query')) {
+      return { ok: true, status: 200, json: async () => 'task-1' };
+    }
+    if (url.startsWith('/api/fetch_query_result')) {
+      return {
+        ok: resultStatus < 400,
+        status: resultStatus,
+        json: async () =>
+          reactions.map(id => ({
+            reaction_id: id,
+            dataset_id: 'ord_dataset-1',
+            proto: encodedReaction(id),
+          })),
+      };
+    }
+    // Chart data and per-card summaries.
+    if (url.startsWith('/api/reaction_summary')) {
+      return { ok: true, status: 200, text: async () => '' };
+    }
+    return { ok: true, status: 200, json: async () => [] };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const renderDataset = (datasetId = 'ord_dataset-1') => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/dataset/${datasetId}`]}>
+        <Routes>
+          <Route
+            path="/dataset/:datasetId"
+            element={<MainDatasetView />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('MainDatasetView', () => {
+  it('shows the dataset metadata', async () => {
+    stubApi({});
+    renderDataset();
+
+    expect(await screen.findByText('Suzuki couplings')).toBeInTheDocument();
+    expect(screen.getByText('from the literature')).toBeInTheDocument();
+    expect(screen.getByText('500')).toBeInTheDocument();
+  });
+
+  it('fills in placeholders for missing metadata', async () => {
+    stubApi({ dataset: { body: { dataset_id: 'ord_dataset-1' } } });
+    renderDataset();
+
+    expect(await screen.findByText('(no name)')).toBeInTheDocument();
+    expect(screen.getByText('(no description)')).toBeInTheDocument();
+  });
+
+  it('reports failed metadata without hiding the rest of the page', async () => {
+    stubApi({ dataset: { status: 500 } });
+    renderDataset();
+
+    expect(
+      await screen.findByText(
+        'Failed to load dataset metadata: dataset metadata failed (HTTP 500)',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('searches the dataset for its reactions', async () => {
+    const fetchMock = stubApi({});
+    renderDataset();
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/submit_query?dataset_id=ord_dataset-1&limit=100',
+        undefined,
+      ),
+    );
+  });
+
+  it('lists the reactions it found', async () => {
+    stubApi({ reactions: ['ord-1', 'ord-2'] });
+    const { container } = renderDataset();
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.reaction-container')).toHaveLength(2),
+    );
+  });
+
+  // The search is capped at 100, so a bigger dataset is shown as a sample.
+  it('marks the results as a sample when the dataset is larger', async () => {
+    stubApi({ reactions: ['ord-1'] });
+    renderDataset();
+
+    expect(
+      await screen.findByText('100 Reactions From This Dataset (Sample)'),
+    ).toBeInTheDocument();
+  });
+
+  it('says so when the dataset has no reactions', async () => {
+    stubApi({ reactions: [] });
+    renderDataset();
+
+    expect(
+      await screen.findByText('This dataset contains no reactions.'),
+    ).toBeInTheDocument();
+  });
+
+  it('reports a failed reaction search', async () => {
+    stubApi({ resultStatus: 500 });
+    renderDataset();
+
+    expect(await screen.findByText(/Failed to load reactions:/)).toBeInTheDocument();
+  });
+
+  it('toggles the chart panel between collapsed and expanded', async () => {
+    const user = userEvent.setup();
+    stubApi({});
+    renderDataset();
+
+    expect(await screen.findByTitle('Expand')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /keyboard_double_arrow/ }));
+    expect(screen.getByTitle('Collapse')).toBeInTheDocument();
+  });
+
+  it('renders a chart for reactants and one for products', async () => {
+    stubApi({});
+    renderDataset();
+
+    expect(await screen.findByText('Frequency of Reactants')).toBeInTheDocument();
+    expect(screen.getByText('Frequency of Products')).toBeInTheDocument();
+  });
+});

--- a/app/src/views/dataset-view/SearchResults.test.tsx
+++ b/app/src/views/dataset-view/SearchResults.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SearchResults from './SearchResults';
+import type { ReactionData, SearchResult } from '../../types/search';
+
+const results = (count: number): SearchResult[] =>
+  Array.from({ length: count }, (_, index) => ({
+    reaction_id: `ord-${index}`,
+    dataset_id: 'ord_dataset-1',
+    proto: '',
+    data: {} as ReactionData,
+  }));
+
+const renderResults = (searchResults: SearchResult[], isOverflow = false) =>
+  render(
+    <MemoryRouter>
+      <SearchResults
+        searchResults={searchResults}
+        isOverflow={isOverflow}
+      />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, status: 200, text: async () => '' })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('dataset SearchResults', () => {
+  it('renders an empty shell without results', () => {
+    const { container } = renderResults([]);
+    expect(container.querySelector('.search-results')).toBeEmptyDOMElement();
+  });
+
+  it('counts the reactions in the title', async () => {
+    renderResults(results(3));
+    expect(
+      await screen.findByText('Reactions in this Dataset (3 Reactions)'),
+    ).toBeInTheDocument();
+  });
+
+  // A dataset larger than the 100-result cap is shown as a sample, and the
+  // title has to say so rather than implying the dataset is that small.
+  it('says so when the results are only a sample', async () => {
+    renderResults(results(3), true);
+    expect(
+      await screen.findByText('100 Reactions From This Dataset (Sample)'),
+    ).toBeInTheDocument();
+  });
+
+  // Selection belongs to search, not to browsing a dataset.
+  it('renders the cards without selection checkboxes', async () => {
+    renderResults(results(2));
+    await screen.findByText(/Reactions in this Dataset/);
+    expect(screen.queryByLabelText('Select reaction')).not.toBeInTheDocument();
+  });
+
+  it('opens the download modal', async () => {
+    const user = userEvent.setup();
+    renderResults(results(2));
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Download All Search Results' }),
+    );
+
+    expect(screen.getByText('Download Results')).toBeInTheDocument();
+  });
+});

--- a/app/src/views/nl-search/MainNLSearch.test.tsx
+++ b/app/src/views/nl-search/MainNLSearch.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import reaction_pb from 'ord-schema';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MainNLSearch from './MainNLSearch';
+import type { NLQueryResponse } from '../../types/search';
+
+const encodedReaction = (reactionId: string): string => {
+  const reaction = new reaction_pb.Reaction();
+  reaction.setReactionId(reactionId);
+  return btoa(String.fromCharCode(...reaction.serializeBinary()));
+};
+
+const response = (overrides: Partial<NLQueryResponse> = {}): NLQueryResponse => ({
+  query: 'reactions using benzene',
+  interpretation: {
+    components: [{ identifier: 'benzene', target: 'INPUT', mode: 'EXACT' }],
+  },
+  resolved_components: [
+    {
+      identifier: 'benzene',
+      smiles: 'c1ccccc1',
+      resolver: 'pubchem',
+      target: 'INPUT',
+      mode: 'EXACT',
+    },
+  ],
+  query_components: [],
+  results: [{ reaction_id: 'ord-1', proto: encodedReaction('ord-1') }],
+  dry_run: false,
+  ...overrides,
+});
+
+let currentSearch = '';
+
+const LocationSpy = () => {
+  currentSearch = useLocation().search;
+  return null;
+};
+
+const stubApi = (body: NLQueryResponse, status = 200) => {
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.startsWith('/api/nl_query')) {
+      return { ok: status < 400, status, json: async () => body };
+    }
+    // Each result card asks for its own summary.
+    return { ok: true, status: 200, text: async () => '' };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const renderAsk = (search = '') => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  currentSearch = search;
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/ask${search}`]}>
+        <LocationSpy />
+        <MainNLSearch />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+const queryBox = () => screen.getByRole('textbox');
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('MainNLSearch', () => {
+  it('flags the feature as in development', () => {
+    stubApi(response());
+    renderAsk();
+    expect(screen.getByRole('status')).toHaveTextContent(/in development/);
+  });
+
+  it('runs nothing until a question is submitted', () => {
+    const fetchMock = stubApi(response());
+    renderAsk();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('puts the submitted question in the URL so it can be shared', async () => {
+    const user = userEvent.setup();
+    stubApi(response());
+    renderAsk();
+
+    await user.type(queryBox(), 'reactions using benzene');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() =>
+      expect(new URLSearchParams(currentSearch).get('q')).toBe(
+        'reactions using benzene',
+      ),
+    );
+  });
+
+  it('trims the question before submitting', async () => {
+    const user = userEvent.setup();
+    stubApi(response());
+    renderAsk();
+
+    await user.type(queryBox(), '   benzene   ');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() =>
+      expect(new URLSearchParams(currentSearch).get('q')).toBe('benzene'),
+    );
+  });
+
+  it('submits an example question on click', async () => {
+    const user = userEvent.setup();
+    stubApi(response());
+    renderAsk();
+
+    await user.click(
+      screen.getByRole('button', { name: 'reactions for synthesizing ibuprofen' }),
+    );
+
+    await waitFor(() =>
+      expect(new URLSearchParams(currentSearch).get('q')).toBe(
+        'reactions for synthesizing ibuprofen',
+      ),
+    );
+  });
+
+  it('fills the box from a question already in the URL', () => {
+    stubApi(response());
+    renderAsk('?q=reactions%20using%20benzene');
+    expect(queryBox()).toHaveValue('reactions using benzene');
+  });
+
+  describe('the interpretation panel', () => {
+    it('reports each component with its role and match mode', async () => {
+      stubApi(response());
+      renderAsk('?q=reactions%20using%20benzene');
+
+      expect(await screen.findByText('reactant/reagent')).toBeInTheDocument();
+      expect(screen.getByText('benzene', { selector: 'strong' })).toBeInTheDocument();
+      expect(screen.getByText('(exact)')).toBeInTheDocument();
+    });
+
+    it('labels an output component as a product', async () => {
+      stubApi(
+        response({
+          interpretation: {
+            components: [
+              { identifier: 'ibuprofen', target: 'OUTPUT', mode: 'SIMILAR' },
+            ],
+          },
+          resolved_components: [],
+        }),
+      );
+      renderAsk('?q=ibuprofen');
+
+      expect(await screen.findByText('product')).toBeInTheDocument();
+      expect(screen.getByText('(similar)')).toBeInTheDocument();
+    });
+
+    it('says so when the model extracted no components', async () => {
+      stubApi(
+        response({ interpretation: { components: [] }, resolved_components: [] }),
+      );
+      renderAsk('?q=anything');
+
+      expect(await screen.findByText('(no components extracted)')).toBeInTheDocument();
+    });
+
+    it('spells out the numeric and flag filters', async () => {
+      stubApi(
+        response({
+          interpretation: {
+            components: [],
+            min_yield: 70,
+            max_yield: 95,
+            min_conversion: 10,
+            max_conversion: 90,
+            reaction_smarts: '[C:1]>>[C:1]O',
+            similarity_threshold: 0.8,
+            use_stereochemistry: true,
+            limit: 25,
+          },
+          resolved_components: [],
+        }),
+      );
+      renderAsk('?q=anything');
+
+      expect(await screen.findByText('yield ≥ 70%')).toBeInTheDocument();
+      expect(screen.getByText('yield ≤ 95%')).toBeInTheDocument();
+      expect(screen.getByText('conversion ≥ 10%')).toBeInTheDocument();
+      expect(screen.getByText('conversion ≤ 90%')).toBeInTheDocument();
+      expect(screen.getByText('reaction SMARTS [C:1]>>[C:1]O')).toBeInTheDocument();
+      expect(screen.getByText('similarity threshold 0.8')).toBeInTheDocument();
+      expect(screen.getByText('stereochemistry respected')).toBeInTheDocument();
+      expect(screen.getByText('limit 25')).toBeInTheDocument();
+    });
+
+    // A zero bound is a real filter; only null/undefined means "not set".
+    it('keeps a zero-valued filter', async () => {
+      stubApi(
+        response({
+          interpretation: { components: [], min_yield: 0 },
+          resolved_components: [],
+        }),
+      );
+      renderAsk('?q=anything');
+
+      expect(await screen.findByText('yield ≥ 0%')).toBeInTheDocument();
+    });
+
+    it('shows what each name resolved to, and by which resolver', async () => {
+      stubApi(response());
+      renderAsk('?q=reactions%20using%20benzene');
+
+      expect(await screen.findByText('c1ccccc1')).toBeInTheDocument();
+      expect(screen.getByText('via pubchem')).toBeInTheDocument();
+      expect(screen.getByText('(pubchem)')).toBeInTheDocument();
+    });
+
+    // A structure the model supplied directly was never looked up, so it does
+    // not belong in the resolution layer.
+    it('leaves verbatim structures out of the resolution layer', async () => {
+      stubApi(
+        response({
+          resolved_components: [
+            {
+              identifier: 'c1ccccc1',
+              smiles: 'c1ccccc1',
+              resolver: '(verbatim)',
+              target: 'INPUT',
+              mode: 'EXACT',
+            },
+          ],
+        }),
+      );
+      renderAsk('?q=anything');
+
+      await screen.findByText('From the model', { exact: false });
+      expect(screen.queryByText(/Resolved to structures/)).not.toBeInTheDocument();
+    });
+
+    // A fresh and a cached hit from the same service are one resolver.
+    it('counts a cached resolver once', async () => {
+      stubApi(
+        response({
+          resolved_components: [
+            {
+              identifier: 'benzene',
+              smiles: 'c1ccccc1',
+              resolver: 'pubchem',
+              target: 'INPUT',
+              mode: 'EXACT',
+            },
+            {
+              identifier: 'toluene',
+              smiles: 'Cc1ccccc1',
+              resolver: 'pubchem (cached)',
+              target: 'INPUT',
+              mode: 'EXACT',
+            },
+          ],
+        }),
+      );
+      renderAsk('?q=anything');
+
+      expect(await screen.findByText('(pubchem)')).toBeInTheDocument();
+    });
+  });
+
+  describe('results', () => {
+    it('renders the matching reactions', async () => {
+      stubApi(response());
+      const { container } = renderAsk('?q=reactions%20using%20benzene');
+
+      await waitFor(() =>
+        expect(container.querySelectorAll('.reaction-container')).toHaveLength(1),
+      );
+    });
+
+    it('says so when nothing matched', async () => {
+      stubApi(response({ results: [] }));
+      renderAsk('?q=anything');
+
+      expect(await screen.findByText(/No reactions matched/)).toBeInTheDocument();
+    });
+
+    it('reports a failed query', async () => {
+      stubApi(response(), 500);
+      renderAsk('?q=anything');
+
+      expect(await screen.findByText('nl_query failed (HTTP 500)')).toBeInTheDocument();
+    });
+  });
+
+  describe('dry run', () => {
+    it('reads the flag from the URL and skips the search', async () => {
+      stubApi(response({ dry_run: true }), 200);
+      renderAsk('?q=anything&dry_run=1');
+
+      expect(
+        await screen.findByText('Dry run — search not executed'),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('puts the flag in the URL when toggled on', async () => {
+      const user = userEvent.setup();
+      stubApi(response());
+      renderAsk('?q=benzene');
+
+      await user.click(screen.getByRole('checkbox'));
+
+      await waitFor(() =>
+        expect(new URLSearchParams(currentSearch).get('dry_run')).toBe('1'),
+      );
+      expect(new URLSearchParams(currentSearch).get('q')).toBe('benzene');
+    });
+
+    it('drops the flag from the URL when toggled off', async () => {
+      const user = userEvent.setup();
+      stubApi(response({ dry_run: true }));
+      renderAsk('?q=benzene&dry_run=1');
+
+      await user.click(screen.getByRole('checkbox'));
+
+      await waitFor(() =>
+        expect(new URLSearchParams(currentSearch).has('dry_run')).toBe(false),
+      );
+    });
+  });
+});

--- a/app/src/views/reaction-view/CompoundView.test.tsx
+++ b/app/src/views/reaction-view/CompoundView.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CompoundView from './CompoundView';
+
+const SMILES = 2;
+const NAME = 6;
+const REAGENT_ROLE = 2;
+
+const renderCompound = (component: unknown) =>
+  render(<CompoundView component={component as never} />);
+
+const openRawData = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByText('<>'));
+};
+
+// Each raw-data line is a <pre>, and JSX splits the label and the JSON into
+// separate text nodes, so read the lines whole rather than by text match.
+const rawLines = (container: HTMLElement): string[] =>
+  [...container.querySelectorAll('.data pre')].map(line => line.textContent ?? '');
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => '<svg class="mol"></svg>',
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('CompoundView', () => {
+  it('renders without a component', () => {
+    const { container } = renderCompound(undefined);
+    expect(container.querySelector('.compound-view')).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows the amount column only when there is an amount', () => {
+    const { unmount } = renderCompound({});
+    expect(screen.queryByText('Amount')).not.toBeInTheDocument();
+    unmount();
+
+    renderCompound({ amount: { mass: { value: 250, units: 3 } } });
+    expect(screen.getByText('Amount')).toBeInTheDocument();
+    expect(screen.getByText('250 milligram')).toBeInTheDocument();
+  });
+
+  it('shows the reaction role in lowercase', () => {
+    const { container } = renderCompound({ reactionRole: REAGENT_ROLE });
+    expect(container.querySelector('.role')).toHaveTextContent('reagent');
+  });
+
+  it('leaves the role blank when none was recorded', () => {
+    const { container } = renderCompound({});
+    expect(container.querySelector('.role')).toBeEmptyDOMElement();
+  });
+
+  describe('the compound drawing', () => {
+    it('posts the SMILES identifier and renders the returned SVG', async () => {
+      const { container } = renderCompound({
+        identifiersList: [{ type: SMILES, value: 'CCO' }],
+      });
+
+      await waitFor(() =>
+        expect(container.querySelector('.svg')?.innerHTML).toBe(
+          '<svg class="mol"></svg>',
+        ),
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/compound_svg',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-protobuf' },
+        }),
+      );
+    });
+
+    // Without a SMILES there is nothing to draw, so no request should go out.
+    it('skips the request when no identifier is a SMILES', () => {
+      renderCompound({ identifiersList: [{ type: NAME, value: 'ethanol' }] });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    // The 4xx/5xx body is an HTML error page, not an SVG.
+    it('does not render an error page in the drawing slot', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const json = vi.fn();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({ ok: false, status: 500, json })),
+      );
+
+      const { container } = renderCompound({
+        identifiersList: [{ type: SMILES, value: 'CCO' }],
+      });
+
+      await waitFor(() => expect(consoleError).toHaveBeenCalled());
+      expect(json).not.toHaveBeenCalled();
+      expect(container.querySelector('.svg')).toBeEmptyDOMElement();
+    });
+
+    it('survives a network error', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => Promise.reject(new Error('offline'))),
+      );
+
+      const { container } = renderCompound({
+        identifiersList: [{ type: SMILES, value: 'CCO' }],
+      });
+
+      await waitFor(() => expect(consoleError).toHaveBeenCalled());
+      expect(container.querySelector('.svg')).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('the raw data modal', () => {
+    it('names the identifier types', async () => {
+      const user = userEvent.setup();
+      const { container } = renderCompound({
+        identifiersList: [{ type: SMILES, value: 'CCO' }],
+      });
+
+      await openRawData(user);
+
+      expect(rawLines(container)).toContain(
+        'identifiers: {"type":"SMILES","value":"CCO"}',
+      );
+    });
+
+    it('reports the amount under its category', async () => {
+      const user = userEvent.setup();
+      const { container } = renderCompound({
+        amount: { volume: { value: 10, units: 2 } },
+      });
+
+      await openRawData(user);
+
+      expect(rawLines(container)).toContain(
+        'amount: {"volume":{"value":10,"units":"MILLILITER"}}',
+      );
+    });
+
+    it('omits the amount when none was recorded', async () => {
+      const user = userEvent.setup();
+      const { container } = renderCompound({ reactionRole: REAGENT_ROLE });
+
+      await openRawData(user);
+
+      expect(rawLines(container)).toEqual(['reaction_role: REAGENT']);
+    });
+
+    it('names the preparation types', async () => {
+      const user = userEvent.setup();
+      const { container } = renderCompound({
+        preparationsList: [{ type: 2, details: 'used as received' }],
+      });
+
+      await openRawData(user);
+
+      expect(rawLines(container)).toContain(
+        'preparations: {"type":"NONE","details":"used as received"}',
+      );
+    });
+
+    it('reports the product-only fields', async () => {
+      const user = userEvent.setup();
+      const { container } = renderCompound({
+        isolatedColor: 'white',
+        texture: { type: 2, details: 'fine' },
+      });
+
+      await openRawData(user);
+
+      expect(rawLines(container)).toContain('isolated_color: white');
+      expect(rawLines(container)).toContain('texture: {"type":"2","details":"fine"}');
+    });
+
+    it('closes again', async () => {
+      const user = userEvent.setup();
+      renderCompound({ reactionRole: REAGENT_ROLE });
+
+      await openRawData(user);
+      await user.click(screen.getByText('✕'));
+
+      expect(screen.queryByText('Raw Data')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/src/views/reaction-view/ConditionsView.test.tsx
+++ b/app/src/views/reaction-view/ConditionsView.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ConditionsView from './ConditionsView';
+import type { ReactionConditionsData } from '../../types/search';
+
+// Each pane is a grid of alternating .label/.value cells; read it back as a
+// label-to-value map so the assertions read like the rendered table.
+const fields = (container: HTMLElement): Record<string, string> => {
+  const details = container.querySelector('.details');
+  if (!details) return {};
+  const labels = [...details.querySelectorAll('.label')].map(
+    el => el.textContent ?? '',
+  );
+  const values = [...details.querySelectorAll('.value')].map(
+    el => el.textContent ?? '',
+  );
+  return Object.fromEntries(labels.map((label, index) => [label, values[index] ?? '']));
+};
+
+const renderConditions = (conditions: unknown, display: string) =>
+  fields(
+    render(
+      <ConditionsView
+        conditions={conditions as ReactionConditionsData}
+        display={display}
+      />,
+    ).container,
+  );
+
+describe('ConditionsView', () => {
+  it('renders nothing without conditions', () => {
+    const { container } = render(
+      <ConditionsView
+        conditions={undefined}
+        display="temperature"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for an unknown pane', () => {
+    const { container } = render(
+      <ConditionsView
+        conditions={{} as ReactionConditionsData}
+        display="nonsense"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('temperature', () => {
+    it('shows the control type, details and setpoint', () => {
+      expect(
+        renderConditions(
+          {
+            temperature: {
+              control: { type: 3, details: 'silicone oil' },
+              setpoint: { value: 80, units: 1, precision: 0 },
+            },
+          },
+          'temperature',
+        ),
+      ).toEqual({
+        'Control Type': 'OIL_BATH',
+        Details: 'silicone oil',
+        Setpoint: '80 °C',
+      });
+    });
+
+    it('reports a missing setpoint as "None"', () => {
+      expect(renderConditions({ temperature: {} }, 'temperature')).toEqual({
+        'Control Type': '',
+        Setpoint: 'None',
+      });
+    });
+
+    it('counts the recorded measurements', () => {
+      expect(
+        renderConditions({ temperature: { measurementsList: [{}, {}] } }, 'temperature')
+          .Measurements,
+      ).toBe('2 recorded');
+    });
+  });
+
+  describe('pressure', () => {
+    it('shows the control type, setpoint and atmosphere', () => {
+      expect(
+        renderConditions(
+          {
+            pressure: {
+              control: { type: 5, details: 'balloon' },
+              setpoint: { value: 3, units: 1, precision: 0 },
+              atmosphere: { type: 6, details: 'from a balloon' },
+            },
+          },
+          'pressure',
+        ),
+      ).toEqual({
+        'Control Type': 'PRESSURIZED',
+        Details: 'balloon',
+        Setpoint: '3 bar',
+        Atmosphere: 'HYDROGEN, from a balloon',
+      });
+    });
+
+    it('counts the recorded measurements', () => {
+      expect(
+        renderConditions({ pressure: { measurementsList: [{}] } }, 'pressure')
+          .Measurements,
+      ).toBe('1 recorded');
+    });
+  });
+
+  describe('stirring', () => {
+    it('shows the type, rate and RPM', () => {
+      expect(
+        renderConditions(
+          {
+            stirring: {
+              type: 3,
+              details: 'egg-shaped bar',
+              rate: { type: 1, rpm: 500 },
+            },
+          },
+          'stirring',
+        ),
+      ).toEqual({
+        Type: 'STIR_BAR',
+        Details: 'egg-shaped bar',
+        Rate: 'HIGH',
+        RPM: '500',
+      });
+    });
+
+    // An unset rate reads as UNSPECIFIED rather than as a blank cell.
+    it('falls back to UNSPECIFIED without a rate', () => {
+      expect(renderConditions({ stirring: { type: 3 } }, 'stirring').Rate).toBe(
+        'UNSPECIFIED',
+      );
+    });
+
+    // proto3 defaults rpm to 0, which is not a real stirring rate.
+    it('hides a zero RPM', () => {
+      expect(
+        renderConditions(
+          { stirring: { type: 3, rate: { type: 1, rpm: 0 } } },
+          'stirring',
+        ),
+      ).not.toHaveProperty('RPM');
+    });
+  });
+
+  describe('illumination', () => {
+    it('shows the type, wavelength, color and distance', () => {
+      expect(
+        renderConditions(
+          {
+            illumination: {
+              type: 4,
+              details: '450 nm',
+              color: 'blue',
+              peakWavelength: { value: 450, units: 2, precision: 0 },
+              distanceToVessel: { value: 5, units: 1, precision: 0 },
+            },
+          },
+          'illumination',
+        ),
+      ).toEqual({
+        Type: 'LED: 450 nm',
+        'Peak Wavelength': '450 millimeter',
+        Color: 'blue',
+        'Distance to Vessel': '5 centimeter',
+      });
+    });
+
+    it('reports missing lengths as "None"', () => {
+      expect(renderConditions({ illumination: { type: 3 } }, 'illumination')).toEqual({
+        Type: 'DARK',
+        'Peak Wavelength': 'None',
+        'Distance to Vessel': 'None',
+      });
+    });
+  });
+
+  describe('electrochemistry', () => {
+    it('shows the type and the electrode materials', () => {
+      expect(
+        renderConditions(
+          {
+            electrochemistry: {
+              type: 2,
+              details: '10 mA',
+              anodeMaterial: 'graphite',
+              cathodeMaterial: 'nickel',
+            },
+          },
+          'electrochemistry',
+        ),
+      ).toEqual({
+        Type: 'CONSTANT_CURRENT',
+        Details: '10 mA',
+        Anode: 'graphite',
+        Cathode: 'nickel',
+      });
+    });
+
+    it('omits the electrodes when they were not recorded', () => {
+      expect(
+        renderConditions({ electrochemistry: { type: 3 } }, 'electrochemistry'),
+      ).toEqual({ Type: 'CONSTANT_VOLTAGE' });
+    });
+  });
+
+  describe('flow', () => {
+    it('shows the type and pump', () => {
+      expect(
+        renderConditions(
+          { flow: { type: 2, details: 'PFA tubing', pumpType: 'syringe' } },
+          'flow',
+        ),
+      ).toEqual({
+        Type: 'PLUG_FLOW_REACTOR',
+        Details: 'PFA tubing',
+        'Pump Type': 'syringe',
+      });
+    });
+  });
+
+  describe('other', () => {
+    it('shows the flags and details that were set', () => {
+      expect(
+        renderConditions(
+          {
+            reflux: true,
+            ph: 7.4,
+            conditionsAreDynamic: true,
+            details: 'ramped over 2 h',
+          },
+          'other',
+        ),
+      ).toEqual({
+        Reflux: 'yes',
+        pH: '7.4',
+        'Conditions are dynamic': 'yes',
+        Details: 'ramped over 2 h',
+      });
+    });
+
+    // proto3 defaults pH to 0, which is indistinguishable from a strongly
+    // acidic reading, so it is treated as unset.
+    it('hides an unset pH', () => {
+      expect(renderConditions({ ph: 0, reflux: true }, 'other')).toEqual({
+        Reflux: 'yes',
+      });
+    });
+
+    it('shows nothing when no other conditions were recorded', () => {
+      expect(renderConditions({}, 'other')).toEqual({});
+    });
+  });
+});

--- a/app/src/views/reaction-view/EventsView.test.tsx
+++ b/app/src/views/reaction-view/EventsView.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { RecordEvent } from 'ord-schema/proto/reaction_pb';
+import { describe, expect, it } from 'vitest';
+import EventsView from './EventsView';
+
+const renderEvents = (events: unknown[]) =>
+  render(<EventsView events={events as RecordEvent.AsObject[]} />);
+
+const fields = (container: HTMLElement): Record<string, string> => {
+  const details = container.querySelector('.details');
+  if (!details) return {};
+  const labels = [...details.querySelectorAll('.label')].map(
+    el => el.textContent ?? '',
+  );
+  const values = [...details.querySelectorAll('.value')].map(
+    el => el.textContent ?? '',
+  );
+  return Object.fromEntries(labels.map((label, index) => [label, values[index] ?? '']));
+};
+
+const created = (details: string, person: Record<string, string> = {}) => ({
+  time: { value: '2021-05-04T12:00:00Z' },
+  details,
+  person,
+});
+
+describe('EventsView', () => {
+  it('renders nothing without events', () => {
+    const { container } = renderEvents([]);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the details and every recorded person field', () => {
+    const { container } = renderEvents([
+      created('record created', {
+        username: 'alovelace',
+        name: 'Ada Lovelace',
+        orcid: '0000-0001-2345-6789',
+        organization: 'ORD',
+        email: 'ada@example.com',
+      }),
+    ]);
+
+    expect(fields(container)).toEqual({
+      Details: 'record created',
+      Username: 'alovelace',
+      Name: 'Ada Lovelace',
+      ORCID: '0000-0001-2345-6789',
+      Organization: 'ORD',
+      Email: 'ada@example.com',
+    });
+  });
+
+  it('omits the person fields that were not recorded', () => {
+    const { container } = renderEvents([created('record created', { name: 'Ada' })]);
+    expect(fields(container)).toEqual({ Details: 'record created', Name: 'Ada' });
+  });
+
+  it('opens on the first event and switches on click', async () => {
+    const user = userEvent.setup();
+    const { container } = renderEvents([created('first edit'), created('second edit')]);
+    expect(fields(container)).toEqual({ Details: 'first edit' });
+
+    const tabs = [...container.querySelectorAll('.tab')];
+    await user.click(tabs[1]);
+
+    expect(fields(container)).toEqual({ Details: 'second edit' });
+    expect(tabs[1]).toHaveClass('selected');
+  });
+
+  it('leaves the tab unlabeled when the event has no timestamp', () => {
+    const { container } = renderEvents([{ details: 'undated', person: {} }]);
+    expect(container.querySelector('.tab')).toBeEmptyDOMElement();
+  });
+});

--- a/app/src/views/reaction-view/MainReactionView.test.tsx
+++ b/app/src/views/reaction-view/MainReactionView.test.tsx
@@ -1,0 +1,509 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import reaction_pb from 'ord-schema';
+import type { DateTime, Reaction, ReactionInput } from 'ord-schema/proto/reaction_pb';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MainReactionView from './MainReactionView';
+
+const encode = (reaction: Reaction): string =>
+  btoa(String.fromCharCode(...reaction.serializeBinary()));
+
+/** A reaction carrying only the sections each test needs. */
+const buildReaction = (build: (reaction: Reaction) => void = () => {}): string => {
+  const reaction = new reaction_pb.Reaction();
+  reaction.setReactionId('ord-1');
+  build(reaction);
+  return encode(reaction);
+};
+
+const namedInput = (order: number, smiles?: string): ReactionInput => {
+  const input = new reaction_pb.ReactionInput();
+  input.setAdditionOrder(order);
+  if (smiles) {
+    const component = input.addComponents();
+    const identifier = component.addIdentifiers();
+    identifier.setType(reaction_pb.CompoundIdentifier.CompoundIdentifierType.SMILES);
+    identifier.setValue(smiles);
+  }
+  return input;
+};
+
+const timestamp = (value: string): DateTime => {
+  const time = new reaction_pb.DateTime();
+  time.setValue(value);
+  return time;
+};
+
+interface ApiOverrides {
+  proto?: string | null;
+  reactionsStatus?: number;
+  summary?: string;
+  summaryStatus?: number;
+}
+
+// The bodies POSTed to /api/reactions, for the assertions below.
+const posted: RequestInit[] = [];
+
+const stubApi = ({
+  proto,
+  reactionsStatus = 200,
+  summary = '<b>CCO &rarr; CC=O</b>',
+  summaryStatus = 200,
+}: ApiOverrides = {}) => {
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === '/api/reactions') {
+      posted.push(init!);
+      return {
+        ok: reactionsStatus < 400,
+        status: reactionsStatus,
+        json: async () => (proto === null ? [] : [{ proto: proto ?? buildReaction() }]),
+      };
+    }
+    if (url.startsWith('/api/reaction_summary')) {
+      return {
+        ok: summaryStatus < 400,
+        status: summaryStatus,
+        text: async () => summary,
+      };
+    }
+    return { ok: true, status: 200, json: async () => '<svg></svg>' };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const renderReaction = (reactionId = 'ord-1') =>
+  render(
+    <MemoryRouter initialEntries={[`/id/${reactionId}`]}>
+      <Routes>
+        <Route
+          path="/id/:reactionId"
+          element={<MainReactionView />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+const navItems = (container: HTMLElement): string[] =>
+  [...container.querySelectorAll('.nav-item')].map(item => item.textContent ?? '');
+
+const tabsIn = (container: HTMLElement, sectionId: string): string[] =>
+  [...(container.querySelector(`#${sectionId}`)?.querySelectorAll('.tab') ?? [])].map(
+    tab => tab.textContent ?? '',
+  );
+
+afterEach(() => {
+  posted.length = 0;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('MainReactionView', () => {
+  it('requests the reaction and its summary', async () => {
+    const fetchMock = stubApi();
+    renderReaction('ord-42');
+
+    await screen.findByText('Summary');
+    expect(JSON.parse(posted[0].body as string)).toEqual({ reaction_ids: ['ord-42'] });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/reaction_summary?reaction_id=ord-42&compact=false',
+    );
+  });
+
+  it('spins while the reaction is in flight', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    const { container } = renderReaction();
+    expect(container.querySelector('.spinner-main')).toBeInTheDocument();
+  });
+
+  it('renders the summary HTML', async () => {
+    stubApi();
+    const { container } = renderReaction();
+
+    await waitFor(() =>
+      expect(container.querySelector('.summary .display')?.innerHTML).toContain(
+        '<b>CCO → CC=O</b>',
+      ),
+    );
+  });
+
+  // The 4xx/5xx body is an HTML error page, not a reaction drawing.
+  it('leaves the summary blank when it fails to load', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubApi({ summaryStatus: 500, summary: '<h1>500</h1>' });
+    const { container } = renderReaction();
+
+    await screen.findByText('Summary');
+    expect(container.querySelector('.summary')).toBeNull();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('renders an empty page when the reaction is not found', async () => {
+    stubApi({ proto: null });
+    const { container } = renderReaction();
+
+    await waitFor(() => expect(container.querySelector('.spinner-main')).toBeNull());
+    expect(navItems(container)).toEqual([]);
+  });
+
+  it('renders an empty page when the request fails', async () => {
+    stubApi({ reactionsStatus: 500 });
+    const { container } = renderReaction();
+
+    await waitFor(() => expect(container.querySelector('.spinner-main')).toBeNull());
+    expect(navItems(container)).toEqual([]);
+  });
+
+  describe('the section nav', () => {
+    it('lists only the sections the record actually has', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          reaction.getInputsMap().set('m1_m2', namedInput(1, 'CCO'));
+          reaction.setNotes(new reaction_pb.ReactionNotes());
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Summary');
+      expect(navItems(container)).toEqual([
+        'summary',
+        'identifiers',
+        'inputs',
+        'notes',
+        'outcomes',
+        'provenance',
+        'full record',
+      ]);
+    });
+
+    it('adds the optional sections that are populated', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          reaction.setSetup(new reaction_pb.ReactionSetup());
+          reaction.setConditions(new reaction_pb.ReactionConditions());
+          reaction.addObservations().setComment('turned yellow');
+          reaction
+            .addWorkups()
+            .setType(reaction_pb.ReactionWorkup.ReactionWorkupType.WASH);
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Summary');
+      expect(navItems(container)).toContain('setup');
+      expect(navItems(container)).toContain('conditions');
+      expect(navItems(container)).toContain('observations');
+      expect(navItems(container)).toContain('workups');
+    });
+  });
+
+  describe('identifiers', () => {
+    it('names each identifier type', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          const identifier = reaction.addIdentifiers();
+          identifier.setType(
+            reaction_pb.ReactionIdentifier.ReactionIdentifierType.REACTION_SMILES,
+          );
+          identifier.setValue('CCO>>CC=O');
+          identifier.setDetails('from the paper');
+        }),
+      });
+      renderReaction();
+
+      expect(await screen.findByText('REACTION_SMILES')).toBeInTheDocument();
+      expect(screen.getByText('CCO>>CC=O')).toBeInTheDocument();
+      expect(screen.getByText('from the paper')).toBeInTheDocument();
+    });
+
+    it('omits the section when there are none', async () => {
+      stubApi();
+      renderReaction();
+
+      await screen.findByText('Summary');
+      expect(screen.queryByText('Identifiers')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('inputs', () => {
+    // The map arrives in arbitrary order; the view sorts by addition order so
+    // the tabs read as the procedure was run.
+    it('orders the tabs by addition order', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          reaction.getInputsMap().set('added_second', namedInput(2, 'CC=O'));
+          reaction.getInputsMap().set('added_first', namedInput(1, 'CCO'));
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Inputs');
+      expect(tabsIn(container, 'inputs')).toEqual(['added_first', 'added_second']);
+    });
+
+    it('shows the selected input and switches on click', async () => {
+      const user = userEvent.setup();
+      stubApi({
+        proto: buildReaction(reaction => {
+          reaction.getInputsMap().set('first', namedInput(1, 'CCO'));
+          const second = namedInput(2, 'CC=O');
+          second.setAdditionOrder(2);
+          reaction.getInputsMap().set('second', second);
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Inputs');
+      const tabs = [...container.querySelector('#inputs')!.querySelectorAll('.tab')];
+      expect(tabs[0]).toHaveClass('selected');
+
+      await user.click(tabs[1]);
+      expect(tabs[1]).toHaveClass('selected');
+    });
+
+    it('names the addition device, speed and duration', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          const input = namedInput(1, 'CCO');
+          const device = new reaction_pb.ReactionInput.AdditionDevice();
+          device.setType(
+            reaction_pb.ReactionInput.AdditionDevice.AdditionDeviceType.SYRINGE,
+          );
+          input.setAdditionDevice(device);
+          const speed = new reaction_pb.ReactionInput.AdditionSpeed();
+          speed.setType(
+            reaction_pb.ReactionInput.AdditionSpeed.AdditionSpeedType.DROPWISE,
+          );
+          input.setAdditionSpeed(speed);
+          const duration = new reaction_pb.Time();
+          duration.setValue(30);
+          duration.setUnits(reaction_pb.Time.TimeUnit.MINUTE);
+          input.setAdditionDuration(duration);
+          reaction.getInputsMap().set('m1', input);
+        }),
+      });
+      renderReaction();
+
+      await screen.findByText('Inputs');
+      expect(screen.getByText('syringe')).toBeInTheDocument();
+      expect(screen.getByText('dropwise')).toBeInTheDocument();
+      expect(screen.getByText('30 minute(s)')).toBeInTheDocument();
+    });
+  });
+
+  describe('setup', () => {
+    it('offers the automation tab only for an automated setup', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          const setup = new reaction_pb.ReactionSetup();
+          setup.setIsAutomated(true);
+          reaction.setSetup(setup);
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Setup');
+      expect(tabsIn(container, 'setup')).toEqual([
+        'vessel',
+        'environment',
+        'automation',
+      ]);
+    });
+
+    it('hides the automation tab for a manual setup', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          reaction.setSetup(new reaction_pb.ReactionSetup());
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Setup');
+      expect(tabsIn(container, 'setup')).toEqual(['vessel', 'environment']);
+    });
+  });
+
+  describe('conditions', () => {
+    it('offers a tab per populated condition', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          const conditions = new reaction_pb.ReactionConditions();
+          conditions.setTemperature(new reaction_pb.TemperatureConditions());
+          conditions.setStirring(new reaction_pb.StirringConditions());
+          reaction.setConditions(conditions);
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Conditions');
+      expect(tabsIn(container, 'conditions')).toEqual(['temperature', 'stirring']);
+    });
+
+    // "other" has no message of its own; it appears when any of the loose
+    // condition fields is set.
+    it('offers the other tab for a loose condition field', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          const conditions = new reaction_pb.ReactionConditions();
+          conditions.setReflux(true);
+          reaction.setConditions(conditions);
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Conditions');
+      expect(tabsIn(container, 'conditions')).toEqual(['other']);
+    });
+
+    it('switches condition panes on click', async () => {
+      const user = userEvent.setup();
+      stubApi({
+        proto: buildReaction(reaction => {
+          const conditions = new reaction_pb.ReactionConditions();
+          conditions.setTemperature(new reaction_pb.TemperatureConditions());
+          const stirring = new reaction_pb.StirringConditions();
+          stirring.setType(reaction_pb.StirringConditions.StirringMethodType.STIR_BAR);
+          conditions.setStirring(stirring);
+          reaction.setConditions(conditions);
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Conditions');
+      await user.click(
+        [...container.querySelector('#conditions')!.querySelectorAll('.tab')][1],
+      );
+
+      expect(screen.getByText('STIR_BAR')).toBeInTheDocument();
+    });
+  });
+
+  describe('workups', () => {
+    it('labels each tab with a readable workup type', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          reaction
+            .addWorkups()
+            .setType(reaction_pb.ReactionWorkup.ReactionWorkupType.DRY_IN_VACUUM);
+          reaction
+            .addWorkups()
+            .setType(reaction_pb.ReactionWorkup.ReactionWorkupType.FILTRATION);
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Workups');
+      expect(tabsIn(container, 'workups')).toEqual(['dry in vacuum', 'filtration']);
+    });
+
+    it('switches workups on click', async () => {
+      const user = userEvent.setup();
+      stubApi({
+        proto: buildReaction(reaction => {
+          reaction
+            .addWorkups()
+            .setType(reaction_pb.ReactionWorkup.ReactionWorkupType.EXTRACTION);
+          const second = reaction.addWorkups();
+          second.setType(reaction_pb.ReactionWorkup.ReactionWorkupType.FILTRATION);
+          second.setDetails('through celite');
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Workups');
+      await user.click(
+        [...container.querySelector('#workups')!.querySelectorAll('.tab')][1],
+      );
+
+      expect(screen.getByText('through celite')).toBeInTheDocument();
+    });
+  });
+
+  describe('outcomes', () => {
+    it('numbers the outcome tabs', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          reaction.addOutcomes();
+          reaction.addOutcomes();
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Outcomes');
+      expect(tabsIn(container, 'outcomes')).toEqual(['Outcome 1', 'Outcome 2']);
+    });
+  });
+
+  describe('record events', () => {
+    it('labels the creation event and orders events oldest first', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          const provenance = new reaction_pb.ReactionProvenance();
+          const createdEvent = new reaction_pb.RecordEvent();
+          createdEvent.setTime(timestamp('2021-01-01T00:00:00Z'));
+          provenance.setRecordCreated(createdEvent);
+          const modified = provenance.addRecordModified();
+          modified.setTime(timestamp('2020-01-01T00:00:00Z'));
+          modified.setDetails('backdated edit');
+          reaction.setProvenance(provenance);
+        }),
+      });
+      const { container } = renderReaction();
+
+      await screen.findByText('Record Events');
+      const tabs = [...container.querySelector('#events')!.querySelectorAll('.tab')];
+      expect(tabs).toHaveLength(2);
+      // The backdated edit sorts ahead of the creation event.
+      expect(screen.getByText('backdated edit')).toBeInTheDocument();
+    });
+
+    it('omits the section when the record has no creation event', async () => {
+      stubApi({
+        proto: buildReaction(reaction => {
+          const provenance = new reaction_pb.ReactionProvenance();
+          provenance.setCity('Cambridge');
+          reaction.setProvenance(provenance);
+        }),
+      });
+      renderReaction();
+
+      await screen.findByText('Provenance');
+      expect(screen.queryByText('Record Events')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('the full record', () => {
+    it('opens and closes the raw JSON', async () => {
+      const user = userEvent.setup();
+      stubApi();
+      renderReaction();
+
+      await user.click(await screen.findByText('View Full Record'));
+      expect(screen.getByText('Raw Data')).toBeInTheDocument();
+      expect(screen.getByText(/"reactionId": "ord-1"/)).toBeInTheDocument();
+
+      await user.click(screen.getByText('✕'));
+      expect(screen.queryByText('Raw Data')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/src/views/reaction-view/NotesView.test.tsx
+++ b/app/src/views/reaction-view/NotesView.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import NotesView from './NotesView';
+import type { ReactionNotesData } from '../../types/search';
+
+const renderNotes = (notes: unknown): Record<string, string> => {
+  const { container } = render(<NotesView notes={notes as ReactionNotesData} />);
+  const labels = [...container.querySelectorAll('.label')].map(
+    el => el.textContent ?? '',
+  );
+  const values = [...container.querySelectorAll('.value')].map(
+    el => el.textContent ?? '',
+  );
+  return Object.fromEntries(labels.map((label, index) => [label, values[index] ?? '']));
+};
+
+describe('NotesView', () => {
+  it('renders nothing without notes', () => {
+    expect(renderNotes(undefined)).toEqual({});
+  });
+
+  // Field names come straight off the proto, so `isHeterogeneous` has to read
+  // as "heterogeneous" and `procedureDetails` as "procedure details".
+  it('turns camelCase field names into phrases', () => {
+    expect(
+      renderNotes({ isHeterogeneous: true, procedureDetails: 'stirred overnight' }),
+    ).toEqual({
+      heterogeneous: 'true',
+      'procedure details': 'stirred overnight',
+    });
+  });
+
+  // proto3 fills every unset scalar with false / "", which would otherwise
+  // render a row per field in the message.
+  it('skips fields left at their default', () => {
+    expect(
+      renderNotes({
+        isHeterogeneous: false,
+        formsPrecipitate: true,
+        procedureDetails: '',
+      }),
+    ).toEqual({ 'forms precipitate': 'true' });
+  });
+
+  it('renders nothing when every field is at its default', () => {
+    expect(renderNotes({ isHeterogeneous: false, procedureDetails: '' })).toEqual({});
+  });
+});

--- a/app/src/views/reaction-view/ObservationsView.test.tsx
+++ b/app/src/views/reaction-view/ObservationsView.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ObservationsView from './ObservationsView';
+import type { ReactionObservationData } from '../../types/search';
+
+const renderObservations = (observations: unknown[]) =>
+  render(<ObservationsView observations={observations as ReactionObservationData[]} />);
+
+// The rows are a flat grid of .value cells, two per observation.
+const rows = (container: HTMLElement): string[][] => {
+  const cells = [...container.querySelectorAll('.value')].map(
+    el => el.textContent ?? '',
+  );
+  return cells.reduce<string[][]>((pairs, cell, index) => {
+    if (index % 2 === 0) pairs.push([cell]);
+    else pairs[pairs.length - 1].push(cell);
+    return pairs;
+  }, []);
+};
+
+describe('ObservationsView', () => {
+  it('renders nothing without observations', () => {
+    const { container } = renderObservations([]);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('heads the table with Time and Comment', () => {
+    renderObservations([{ comment: 'turned yellow' }]);
+    expect(screen.getByText('Time')).toBeInTheDocument();
+    expect(screen.getByText('Comment')).toBeInTheDocument();
+  });
+
+  it('renders a row per observation, in order', () => {
+    const { container } = renderObservations([
+      { time: { value: 5, units: 2 }, comment: 'turned yellow' },
+      { time: { value: 2, units: 1 }, comment: 'precipitate formed' },
+    ]);
+
+    expect(rows(container)).toEqual([
+      ['5 minute(s)', 'turned yellow'],
+      ['2 hour(s)', 'precipitate formed'],
+    ]);
+  });
+
+  it('leaves the time blank when none was recorded', () => {
+    const { container } = renderObservations([{ comment: 'turned yellow' }]);
+    expect(rows(container)).toEqual([['', 'turned yellow']]);
+  });
+});

--- a/app/src/views/reaction-view/OutcomesView.test.tsx
+++ b/app/src/views/reaction-view/OutcomesView.test.tsx
@@ -1,0 +1,301 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import OutcomesView from './OutcomesView';
+import type { ReactionOutcomeData } from '../../types/search';
+
+const YIELD = 3;
+const CUSTOM = 1;
+const AMOUNT = 9;
+const LC_ANALYSIS = 2;
+
+const renderOutcome = (outcome: unknown) =>
+  render(<OutcomesView outcome={outcome as ReactionOutcomeData} />);
+
+const detailFields = (container: HTMLElement): Record<string, string> => {
+  const details = container.querySelector('.details');
+  if (!details) return {};
+  const labels = [...details.querySelectorAll('.label')].map(
+    el => el.textContent ?? '',
+  );
+  const values = [...details.querySelectorAll('.value')].map(
+    el => el.textContent ?? '',
+  );
+  return Object.fromEntries(labels.map((label, index) => [label, values[index] ?? '']));
+};
+
+// The measurements grid is five columns wide: type, spacer, value, analysis, raw.
+const measurementRows = (container: HTMLElement): string[][] => {
+  const cells = [...(container.querySelector('.measurements')?.children ?? [])].map(
+    cell => cell.textContent ?? '',
+  );
+  const rows: string[][] = [];
+  for (let index = 5; index < cells.length; index += 5) {
+    rows.push(cells.slice(index, index + 5));
+  }
+  return rows;
+};
+
+const product = (measurementsList: unknown[]) => ({
+  identifiersList: [],
+  measurementsList,
+});
+
+beforeEach(() => {
+  // CompoundView, rendered for the selected product, asks for a drawing.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, status: 200, json: async () => '<svg></svg>' })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('OutcomesView', () => {
+  it('renders nothing without an outcome', () => {
+    const { container } = renderOutcome(undefined);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('details', () => {
+    it('shows the reaction time and conversion', () => {
+      const { container } = renderOutcome({
+        reactionTime: { value: 2, units: 1, precision: 0 },
+        conversion: { value: 95, precision: 2 },
+      });
+
+      expect(detailFields(container)).toEqual({
+        'Reaction Time': '2 hour(s)',
+        Conversion: '95% ± 2',
+      });
+    });
+
+    it('omits the details section when neither was recorded', () => {
+      renderOutcome({ productsList: [] });
+      expect(screen.queryByText('Details')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('products', () => {
+    it('renders a tab per product and opens the first', () => {
+      const { container } = renderOutcome({
+        productsList: [product([]), product([])],
+      });
+
+      const tabs = [...container.querySelectorAll('.tab')];
+      expect(tabs.map(tab => tab.textContent)).toEqual(['Product 1', 'Product 2']);
+      expect(tabs[0]).toHaveClass('selected');
+    });
+
+    it('switches products on click', async () => {
+      const user = userEvent.setup();
+      const { container } = renderOutcome({
+        productsList: [
+          product([{ type: YIELD, percentage: { value: 10, precision: 0 } }]),
+          product([{ type: YIELD, percentage: { value: 20, precision: 0 } }]),
+        ],
+      });
+
+      await user.click([...container.querySelectorAll('.tab')][1]);
+
+      expect(measurementRows(container)[0][2]).toBe('20%');
+    });
+  });
+
+  describe('measurements', () => {
+    it('renders a percentage measurement', () => {
+      const { container } = renderOutcome({
+        productsList: [
+          product([
+            {
+              type: YIELD,
+              percentage: { value: 82.35, precision: 0 },
+              analysisKey: 'lcms',
+            },
+          ]),
+        ],
+      });
+
+      expect(measurementRows(container)).toEqual([
+        ['YIELD', '', '82.4%', 'lcms', '<>'],
+      ]);
+    });
+
+    it('renders an amount measurement', () => {
+      const { container } = renderOutcome({
+        productsList: [
+          product([
+            {
+              type: AMOUNT,
+              amount: { mass: { value: 250, units: 3, precision: 0 } },
+              analysisKey: '',
+            },
+          ]),
+        ],
+      });
+
+      expect(measurementRows(container)[0][2]).toBe('250 milligram');
+    });
+
+    it('renders a float measurement', () => {
+      const { container } = renderOutcome({
+        productsList: [
+          product([{ type: AMOUNT, floatValue: { value: 1.5 }, analysisKey: '' }]),
+        ],
+      });
+
+      expect(measurementRows(container)[0][2]).toBe('1.5');
+    });
+
+    it('renders a string measurement', () => {
+      const { container } = renderOutcome({
+        productsList: [
+          product([{ type: AMOUNT, stringValue: 'trace', analysisKey: '' }]),
+        ],
+      });
+
+      expect(measurementRows(container)[0][2]).toBe('trace');
+    });
+
+    it('leaves the value blank when the oneof is empty', () => {
+      const { container } = renderOutcome({
+        productsList: [product([{ type: AMOUNT, analysisKey: '' }])],
+      });
+
+      expect(measurementRows(container)[0][2]).toBe('');
+    });
+
+    it('opens the raw measurement with its type named', async () => {
+      const user = userEvent.setup();
+      const { container } = renderOutcome({
+        productsList: [
+          product([
+            {
+              type: YIELD,
+              percentage: { value: 50, precision: 0 },
+              analysisKey: 'nmr',
+            },
+          ]),
+        ],
+      });
+
+      await user.click(container.querySelector('.measurements .button')!);
+
+      expect(screen.getByText('Raw Data')).toBeInTheDocument();
+      expect(screen.getByText(/"type": "YIELD"/)).toBeInTheDocument();
+    });
+
+    describe('custom measurements', () => {
+      it('offers the recorded details', async () => {
+        const user = userEvent.setup();
+        renderOutcome({
+          productsList: [
+            product([{ type: CUSTOM, details: 'in-house assay', analysisKey: '' }]),
+          ],
+        });
+
+        await user.click(screen.getByText('CUSTOM'));
+
+        expect(screen.getByText('Custom Measurement Details')).toBeInTheDocument();
+        expect(screen.getByText('in-house assay')).toBeInTheDocument();
+      });
+
+      it('points at the author when no details were recorded', async () => {
+        const user = userEvent.setup();
+        renderOutcome({
+          productsList: [product([{ type: CUSTOM, details: '', analysisKey: '' }])],
+        });
+
+        await user.click(screen.getByText('CUSTOM'));
+
+        expect(
+          screen.getByText(/contact the author for details on this custom measurement/),
+        ).toBeInTheDocument();
+      });
+
+      it('closes the details again', async () => {
+        const user = userEvent.setup();
+        renderOutcome({
+          productsList: [
+            product([{ type: CUSTOM, details: 'in-house assay', analysisKey: '' }]),
+          ],
+        });
+
+        await user.click(screen.getByText('CUSTOM'));
+        await user.click(screen.getByText('✕'));
+
+        expect(
+          screen.queryByText('Custom Measurement Details'),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('analyses', () => {
+    it('omits the section when there are none', () => {
+      renderOutcome({ productsList: [product([])], analysesMap: [] });
+      expect(screen.queryByText('Analyses')).not.toBeInTheDocument();
+    });
+
+    it('names each analysis by its map key and shows the selected one', () => {
+      const { container } = renderOutcome({
+        productsList: [product([])],
+        analysesMap: [
+          ['lcms', { type: LC_ANALYSIS, details: 'method A' }],
+          ['nmr', { type: 5, details: 'method B' }],
+        ],
+      });
+
+      const tabs = [...container.querySelectorAll('.tab')];
+      expect(tabs.map(tab => tab.textContent)).toEqual(['Product 1', 'lcms', 'nmr']);
+      expect(screen.getByText('LC')).toBeInTheDocument();
+      expect(screen.getByText('method A')).toBeInTheDocument();
+    });
+
+    it('switches analyses on click', async () => {
+      const user = userEvent.setup();
+      const { container } = renderOutcome({
+        productsList: [product([])],
+        analysesMap: [
+          ['lcms', { type: LC_ANALYSIS, details: 'method A' }],
+          ['nmr', { type: 5, details: 'method B' }],
+        ],
+      });
+
+      await user.click([...container.querySelectorAll('.tab')][2]);
+
+      expect(screen.getByText('NMR_1H')).toBeInTheDocument();
+      expect(screen.getByText('method B')).toBeInTheDocument();
+    });
+
+    it('opens the raw analysis with its type named', async () => {
+      const user = userEvent.setup();
+      const { container } = renderOutcome({
+        productsList: [product([])],
+        analysesMap: [['lcms', { type: LC_ANALYSIS, details: 'method A' }]],
+      });
+
+      await user.click(container.querySelector('.details .button')!);
+
+      expect(screen.getByText(/"type": "LC"/)).toBeInTheDocument();
+    });
+  });
+});

--- a/app/src/views/reaction-view/ProvenanceView.test.tsx
+++ b/app/src/views/reaction-view/ProvenanceView.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ProvenanceView from './ProvenanceView';
+import type { ReactionProvenanceData } from '../../types/search';
+
+const renderProvenance = (provenance: unknown) =>
+  render(<ProvenanceView provenance={provenance as ReactionProvenanceData} />);
+
+const fields = (container: HTMLElement, selector: string): Record<string, string> => {
+  const details = container.querySelector(selector);
+  if (!details) return {};
+  const labels = [...details.querySelectorAll('.label')].map(
+    el => el.textContent ?? '',
+  );
+  const values = [...details.querySelectorAll('.value')].map(
+    el => el.textContent ?? '',
+  );
+  return Object.fromEntries(labels.map((label, index) => [label, values[index] ?? '']));
+};
+
+describe('ProvenanceView', () => {
+  it('renders an empty view without provenance', () => {
+    const { container } = renderProvenance(undefined);
+    expect(container.querySelector('.provenance-view')).toBeInTheDocument();
+    expect(container.querySelector('.experimenter')).toBeNull();
+  });
+
+  it('shows the experimenter when one was recorded', () => {
+    const { container } = renderProvenance({
+      experimenter: {
+        username: 'alovelace',
+        name: 'Ada Lovelace',
+        orcid: '0000-0001-2345-6789',
+        organization: 'ORD',
+        email: 'ada@example.com',
+      },
+    });
+
+    expect(fields(container, '.experimenter')).toEqual({
+      Username: 'alovelace',
+      Name: 'Ada Lovelace',
+      ORCID: '0000-0001-2345-6789',
+      Organization: 'ORD',
+      Email: 'ada@example.com',
+    });
+  });
+
+  it('omits the experimenter section when none was recorded', () => {
+    renderProvenance({ city: 'Cambridge' });
+    expect(screen.queryByText('Experimenter')).not.toBeInTheDocument();
+  });
+
+  it('shows the city, DOI and patent', () => {
+    const { container } = renderProvenance({
+      city: 'Cambridge',
+      doi: '10.1021/jacs.8b01523',
+      patent: 'US1234567',
+    });
+
+    expect(fields(container, '.details')).toEqual({
+      City: 'Cambridge',
+      DOI: '10.1021/jacs.8b01523',
+      Patent: 'US1234567',
+    });
+  });
+
+  it('links the publication URL', () => {
+    renderProvenance({ publicationUrl: 'https://example.com/paper' });
+    expect(
+      screen.getByRole('link', { name: 'https://example.com/paper' }),
+    ).toHaveAttribute('href', 'https://example.com/paper');
+  });
+
+  it('omits the experiment start when the timestamp is empty', () => {
+    renderProvenance({ experimentStart: { value: '' }, city: 'Cambridge' });
+    expect(screen.queryByText('Experiment Start')).not.toBeInTheDocument();
+  });
+
+  it('shows the experiment start as a date', () => {
+    renderProvenance({ experimentStart: { value: '2021-05-04T12:00:00Z' } });
+    expect(screen.getByText('Experiment Start')).toBeInTheDocument();
+  });
+});

--- a/app/src/views/reaction-view/SetupView.test.tsx
+++ b/app/src/views/reaction-view/SetupView.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import SetupView from './SetupView';
+import type { ReactionSetupData } from '../../types/search';
+
+const fields = (container: HTMLElement): Record<string, string> => {
+  const details = container.querySelector('.details');
+  if (!details) return {};
+  const labels = [...details.querySelectorAll('.label')].map(
+    el => el.textContent ?? '',
+  );
+  const values = [...details.querySelectorAll('.value')].map(
+    el => el.textContent ?? '',
+  );
+  return Object.fromEntries(labels.map((label, index) => [label, values[index] ?? '']));
+};
+
+const renderSetup = (setup: unknown, display: string) =>
+  fields(
+    render(
+      <SetupView
+        setup={setup as ReactionSetupData}
+        display={display}
+      />,
+    ).container,
+  );
+
+describe('SetupView', () => {
+  it('renders no pane for an unknown display', () => {
+    expect(renderSetup({}, 'nonsense')).toEqual({});
+  });
+
+  describe('vessel', () => {
+    it('names the type, material and volume', () => {
+      expect(
+        renderSetup(
+          {
+            vessel: {
+              type: 2,
+              details: 'borosilicate',
+              material: { type: 2 },
+              volume: { value: 25, units: 2, precision: 0 },
+            },
+          },
+          'vessel',
+        ),
+      ).toEqual({
+        Type: 'ROUND_BOTTOM_FLASK',
+        Details: 'borosilicate',
+        Material: 'GLASS',
+        Volume: '25 milliliter',
+      });
+    });
+
+    it('joins the attachments and preparations', () => {
+      expect(
+        renderSetup(
+          {
+            vessel: {
+              type: 2,
+              attachmentsList: [
+                { type: 3, details: 'rubber' },
+                { type: 4, details: '' },
+              ],
+              preparationsList: [{ type: 4, details: '' }],
+            },
+          },
+          'vessel',
+        ),
+      ).toMatchObject({
+        Attachments: 'SEPTUM: rubber, CAP',
+        Preparations: 'FLAME_DRIED',
+      });
+    });
+
+    it('falls back to UNSPECIFIED for a missing material', () => {
+      expect(renderSetup({ vessel: { type: 2 } }, 'vessel')).toEqual({
+        Type: 'ROUND_BOTTOM_FLASK',
+        Material: 'UNSPECIFIED',
+        Volume: '',
+      });
+    });
+
+    it('renders an empty pane without a vessel', () => {
+      expect(renderSetup({}, 'vessel')).toEqual({
+        Type: '',
+        Material: 'UNSPECIFIED',
+        Volume: '',
+      });
+    });
+  });
+
+  describe('environment', () => {
+    it('names the environment type', () => {
+      expect(
+        renderSetup(
+          { environment: { type: 2, details: 'in a glovebox' } },
+          'environment',
+        ),
+      ).toEqual({ Type: 'FUME_HOOD', Details: 'in a glovebox' });
+    });
+
+    it('falls back to UNSPECIFIED when none was recorded', () => {
+      expect(renderSetup({}, 'environment')).toEqual({ Type: 'UNSPECIFIED' });
+    });
+  });
+
+  describe('automation', () => {
+    it('names the platform', () => {
+      expect(renderSetup({ automationPlatform: 'Chemspeed' }, 'automation')).toEqual({
+        Platform: 'Chemspeed',
+      });
+    });
+
+    it('falls back to UNSPECIFIED when none was recorded', () => {
+      expect(renderSetup({}, 'automation')).toEqual({ Platform: 'UNSPECIFIED' });
+    });
+  });
+});

--- a/app/src/views/reaction-view/WorkupsView.test.tsx
+++ b/app/src/views/reaction-view/WorkupsView.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import WorkupsView from './WorkupsView';
+import type { ReactionWorkupData } from '../../types/search';
+
+const SMILES = 2;
+const NAME = 6;
+
+const renderWorkup = (workup: unknown) =>
+  render(<WorkupsView workup={workup as ReactionWorkupData} />);
+
+const fields = (container: HTMLElement): Record<string, string> => {
+  const details = container.querySelector('.details');
+  if (!details) return {};
+  const labels = [...details.querySelectorAll('.label')].map(
+    el => el.textContent ?? '',
+  );
+  const values = [...details.querySelectorAll('.value')].map(
+    el => el.textContent ?? '',
+  );
+  return Object.fromEntries(labels.map((label, index) => [label, values[index] ?? '']));
+};
+
+const inputs = (container: HTMLElement): string[][] => {
+  const identifiers = [...container.querySelectorAll('.identifier')];
+  const amounts = [...container.querySelectorAll('.amount')];
+  return identifiers.map((identifier, index) => [
+    identifier.textContent ?? '',
+    amounts[index]?.textContent ?? '',
+  ]);
+};
+
+describe('WorkupsView', () => {
+  it('renders nothing without a workup', () => {
+    const { container } = renderWorkup(undefined);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('names the workup type and shows what was recorded', () => {
+    const { container } = renderWorkup({
+      type: 6,
+      details: 'washed twice',
+      duration: { value: 30, units: 2, precision: 0 },
+      amount: { volume: { value: 5, units: 2, precision: 0 } },
+      keepPhase: 'organic',
+      targetPh: 7,
+      isAutomated: true,
+    });
+
+    expect(fields(container)).toEqual({
+      Type: 'EXTRACTION',
+      Details: 'washed twice',
+      Duration: '30 minute(s)',
+      'Aliquot amount': '5 milliliter',
+      'Phase kept': 'organic',
+      'Target pH': '7',
+      Automated: 'yes',
+    });
+  });
+
+  it('shows only the type when nothing else was recorded', () => {
+    const { container } = renderWorkup({ type: 7 });
+    expect(fields(container)).toEqual({ Type: 'FILTRATION' });
+  });
+
+  // proto3 defaults targetPh to 0, which is indistinguishable from a real,
+  // strongly acidic reading, so it is treated as unset.
+  it('hides an unset target pH', () => {
+    const { container } = renderWorkup({ type: 6, targetPh: 0 });
+    expect(fields(container)).not.toHaveProperty('Target pH');
+  });
+
+  describe('inputs', () => {
+    it('labels each component by its NAME identifier', () => {
+      const { container } = renderWorkup({
+        type: 6,
+        input: {
+          componentsList: [
+            {
+              identifiersList: [
+                { type: SMILES, value: 'O' },
+                { type: NAME, value: 'water' },
+              ],
+              amount: { volume: { value: 10, units: 2, precision: 0 } },
+            },
+          ],
+        },
+      });
+
+      expect(inputs(container)).toEqual([['water', '10 milliliter']]);
+    });
+
+    // Not every compound carries a NAME, and the view must not blow up on it.
+    it('falls back to the first identifier when there is no NAME', () => {
+      const { container } = renderWorkup({
+        type: 6,
+        input: {
+          componentsList: [
+            {
+              identifiersList: [{ type: SMILES, value: 'CCO' }],
+              amount: { volume: { value: 1, units: 2, precision: 0 } },
+            },
+          ],
+        },
+      });
+
+      expect(inputs(container)).toEqual([['CCO', '1 milliliter']]);
+    });
+
+    it('renders an empty label when the component has no identifiers', () => {
+      const { container } = renderWorkup({
+        type: 6,
+        input: { componentsList: [{ identifiersList: [] }] },
+      });
+
+      expect(inputs(container)).toEqual([['', '']]);
+    });
+
+    it('omits the inputs section when there are no components', () => {
+      const { container } = renderWorkup({ type: 6, input: { componentsList: [] } });
+      expect(container.querySelector('.inputs')).toBeNull();
+    });
+  });
+});

--- a/app/src/views/search/MainSearch.test.tsx
+++ b/app/src/views/search/MainSearch.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import MainSearch from './MainSearch';
+
+let currentSearch = '';
+
+const LocationSpy = () => {
+  currentSearch = useLocation().search;
+  return null;
+};
+
+const renderSearch = (search = '') => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  currentSearch = search;
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/search${search}`]}>
+        <LocationSpy />
+        <MainSearch />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+// The params of the URL the component navigated to, as sorted "key=value" pairs
+// so assertions do not depend on the order they were appended in.
+const navigatedParams = (): string[] =>
+  [...new URLSearchParams(currentSearch).entries()]
+    .map(([key, value]) => `${key}=${value}`)
+    .sort();
+
+const searchButton = () => screen.getByRole('button', { name: 'Search' });
+
+beforeEach(() => {
+  // Never resolves: the submit/poll protocol is exercised in the useSearchTask
+  // tests, and here it just has to stay out of the way.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => new Promise<Response>(() => {})),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('MainSearch', () => {
+  it('prompts for criteria when the URL carries none', () => {
+    renderSearch();
+    expect(screen.getByText(/Enter search criteria/)).toBeInTheDocument();
+  });
+
+  // `limit` alone is not a search; it would otherwise fire an empty query on
+  // every visit.
+  it('does not treat the result limit as search criteria', () => {
+    renderSearch('?limit=100');
+    expect(screen.getByText(/Enter search criteria/)).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('runs a search when the URL carries criteria', () => {
+    renderSearch('?dataset_id=ord_dataset-1');
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/submit_query?dataset_id=ord_dataset-1',
+      undefined,
+    );
+  });
+
+  it('encodes components as JSON with the shared match mode', async () => {
+    const user = userEvent.setup();
+    renderSearch(
+      `?component=${encodeURIComponent(
+        JSON.stringify({ pattern: 'CCO', target: 'input', mode: 'substructure' }),
+      )}`,
+    );
+
+    await user.click(searchButton());
+
+    await waitFor(() =>
+      expect(new URLSearchParams(currentSearch).getAll('component')).toEqual([
+        JSON.stringify({ pattern: 'CCO', target: 'input', mode: 'substructure' }),
+      ]),
+    );
+  });
+
+  it('round-trips a full set of criteria through the URL', async () => {
+    const user = userEvent.setup();
+    const component = JSON.stringify({
+      pattern: 'CCO',
+      target: 'input',
+      mode: 'similar',
+    });
+    const initial = new URLSearchParams({
+      component,
+      use_stereochemistry: 'true',
+      similarity: '0.75',
+      dataset_id: 'ord_dataset-1',
+      doi: '10.1000/x',
+      reaction_id: 'ord-abc',
+      reaction_smarts: '[C:1]>>[C:1]O',
+      min_yield: '20',
+      max_yield: '80',
+      min_conversion: '10',
+      max_conversion: '90',
+      limit: '25',
+    });
+    renderSearch(`?${initial.toString()}`);
+    const before = navigatedParams();
+
+    await user.click(searchButton());
+
+    await waitFor(() => expect(navigatedParams()).toEqual(before));
+  });
+
+  // The backend applies the full range by default, so sending it back would
+  // only bloat the shareable link.
+  it('omits an unnarrowed yield and conversion range', async () => {
+    const user = userEvent.setup();
+    renderSearch('?dataset_id=ord_dataset-1');
+
+    await user.click(searchButton());
+
+    await waitFor(() =>
+      expect(navigatedParams()).toEqual(['dataset_id=ord_dataset-1', 'limit=100']),
+    );
+  });
+
+  // Stereochemistry and similarity only mean something alongside a component.
+  it('omits the component settings when there are no components', async () => {
+    const user = userEvent.setup();
+    renderSearch('?reaction_id=ord-abc');
+
+    await user.click(searchButton());
+
+    await waitFor(() =>
+      expect(navigatedParams()).toEqual(['limit=100', 'reaction_id=ord-abc']),
+    );
+  });
+
+  it('reports a failed search', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response),
+    );
+    renderSearch('?dataset_id=ord_dataset-1');
+
+    expect(
+      await screen.findByText(/Search failed: submit_query failed \(HTTP 500\)/),
+    ).toBeInTheDocument();
+  });
+
+  it('reports an empty result set', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) =>
+        url.startsWith('/api/submit_query')
+          ? ({ ok: true, status: 200, json: async () => 'task-1' } as Response)
+          : ({ ok: true, status: 200, json: async () => [] } as Response),
+      ),
+    );
+    renderSearch('?dataset_id=ord_dataset-1');
+
+    expect(await screen.findByText(/No results/)).toBeInTheDocument();
+  });
+});

--- a/app/src/views/search/SearchItemList.test.tsx
+++ b/app/src/views/search/SearchItemList.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import SearchItemList from './SearchItemList';
+
+const renderList = (itemList: string[] = []) => {
+  const onUpdateItemList = vi.fn();
+  render(
+    <SearchItemList
+      title="Reaction IDs"
+      itemList={itemList}
+      onUpdateItemList={onUpdateItemList}
+    />,
+  );
+  return { onUpdateItemList, input: screen.getByRole('textbox') };
+};
+
+describe('SearchItemList', () => {
+  it('shows the title and the items it was given', () => {
+    renderList(['ord-1', 'ord-2']);
+    expect(screen.getByText('Reaction IDs')).toBeInTheDocument();
+    expect(screen.getByText('ord-1')).toBeInTheDocument();
+    expect(screen.getByText('ord-2')).toBeInTheDocument();
+  });
+
+  it('adds an item and reports the new list', async () => {
+    const user = userEvent.setup();
+    const { onUpdateItemList, input } = renderList(['ord-1']);
+
+    await user.type(input, 'ord-2');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(onUpdateItemList).toHaveBeenCalledWith(['ord-1', 'ord-2']);
+    expect(screen.getByText('ord-2')).toBeInTheDocument();
+  });
+
+  it('clears the input after adding', async () => {
+    const user = userEvent.setup();
+    const { input } = renderList();
+
+    await user.type(input, 'ord-1');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(input).toHaveValue('');
+  });
+
+  it('adds on Enter', async () => {
+    const user = userEvent.setup();
+    const { onUpdateItemList, input } = renderList();
+
+    await user.type(input, 'ord-1{Enter}');
+
+    expect(onUpdateItemList).toHaveBeenCalledWith(['ord-1']);
+  });
+
+  it('ignores Enter on whitespace', async () => {
+    const user = userEvent.setup();
+    const { onUpdateItemList, input } = renderList();
+
+    await user.type(input, '   {Enter}');
+
+    expect(onUpdateItemList).not.toHaveBeenCalled();
+  });
+
+  it('disables the add button until there is something to add', async () => {
+    const user = userEvent.setup();
+    const { input } = renderList();
+    const addButton = screen.getByRole('button', { name: /add/i });
+
+    expect(addButton).toBeDisabled();
+    await user.type(input, '   ');
+    expect(addButton).toBeDisabled();
+    await user.type(input, 'ord-1');
+    expect(addButton).toBeEnabled();
+  });
+
+  it('deletes the item at the clicked position', async () => {
+    const user = userEvent.setup();
+    const { onUpdateItemList } = renderList(['ord-1', 'ord-2', 'ord-3']);
+
+    // The first button in the list is the delete for the first item.
+    const deleteButtons = screen.getAllByRole('button');
+    await user.click(deleteButtons[1]);
+
+    expect(onUpdateItemList).toHaveBeenCalledWith(['ord-1', 'ord-3']);
+    expect(screen.queryByText('ord-2')).not.toBeInTheDocument();
+  });
+
+  it('follows a change of the incoming list', () => {
+    const onUpdateItemList = vi.fn();
+    const { rerender } = render(
+      <SearchItemList
+        title="Reaction IDs"
+        itemList={['ord-1']}
+        onUpdateItemList={onUpdateItemList}
+      />,
+    );
+    expect(screen.getByText('ord-1')).toBeInTheDocument();
+
+    rerender(
+      <SearchItemList
+        title="Reaction IDs"
+        itemList={['ord-9']}
+        onUpdateItemList={onUpdateItemList}
+      />,
+    );
+    expect(screen.queryByText('ord-1')).not.toBeInTheDocument();
+    expect(screen.getByText('ord-9')).toBeInTheDocument();
+  });
+});

--- a/app/src/views/search/SearchOptions.test.tsx
+++ b/app/src/views/search/SearchOptions.test.tsx
@@ -1,0 +1,380 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import SearchOptions from './SearchOptions';
+
+const renderOptions = (search = '') => {
+  const onSearchOptions = vi.fn();
+  render(
+    <MemoryRouter initialEntries={[`/search${search}`]}>
+      <SearchOptions onSearchOptions={onSearchOptions} />
+    </MemoryRouter>,
+  );
+  return { onSearchOptions };
+};
+
+// The text inputs in the components section, in reactants-then-products order.
+const smilesInputs = (): HTMLInputElement[] =>
+  screen
+    .getAllByRole('textbox')
+    .filter(input => input.closest('.reagent.options') !== null) as HTMLInputElement[];
+
+const sectionIsOpen = (heading: string): boolean =>
+  screen.queryByText(heading) !== null;
+
+const search = (params: Record<string, string | string[]>): string => {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    for (const item of Array.isArray(value) ? value : [value]) {
+      query.append(key, item);
+    }
+  }
+  return `?${query.toString()}`;
+};
+
+describe('SearchOptions', () => {
+  it('starts with every optional section collapsed', () => {
+    renderOptions();
+    expect(sectionIsOpen('Reactants & Reagents')).toBe(false);
+    expect(sectionIsOpen('Reaction IDs')).toBe(false);
+    expect(sectionIsOpen('Dataset IDs')).toBe(false);
+    expect(screen.getByLabelText('Result Limit')).toHaveValue(100);
+  });
+
+  it('opens a collapsed section on click', async () => {
+    const user = userEvent.setup();
+    renderOptions();
+
+    await user.click(screen.getByText('Components'));
+
+    expect(sectionIsOpen('Reactants & Reagents')).toBe(true);
+  });
+
+  describe('reading components from the URL', () => {
+    it('accepts the JSON form', () => {
+      renderOptions(
+        search({
+          component: JSON.stringify({
+            pattern: 'CCO',
+            target: 'input',
+            mode: 'substructure',
+          }),
+        }),
+      );
+
+      expect(smilesInputs().map(input => input.value)).toEqual(['CCO']);
+      expect(screen.getByText('substructure')).toHaveClass('selected');
+    });
+
+    // Previously shared URLs used "pattern;target;mode".
+    it('accepts the legacy delimited form', () => {
+      renderOptions(search({ component: 'CCO;input;exact' }));
+
+      expect(smilesInputs().map(input => input.value)).toEqual(['CCO']);
+      expect(screen.getByText('exact')).toHaveClass('selected');
+    });
+
+    // A SMARTS pattern can contain ";" itself, so the legacy parse has to split
+    // from the right.
+    it('keeps semicolons inside a legacy SMARTS pattern', () => {
+      renderOptions(search({ component: '[C;H2];input;smarts' }));
+
+      expect(smilesInputs().map(input => input.value)).toEqual(['[C;H2]']);
+    });
+
+    it('falls back to the legacy parse for JSON that is not a component', () => {
+      renderOptions(search({ component: 'CCO;input;exact' }));
+      expect(smilesInputs().map(input => input.value)).toEqual(['CCO']);
+    });
+
+    it('files inputs as reactants and everything else as products', () => {
+      renderOptions(
+        search({
+          component: [
+            JSON.stringify({ pattern: 'CCO', target: 'input', mode: 'exact' }),
+            JSON.stringify({ pattern: 'CC=O', target: 'output', mode: 'exact' }),
+          ],
+        }),
+      );
+
+      expect(smilesInputs().map(input => input.value)).toEqual(['CCO', 'CC=O']);
+    });
+
+    it('defaults a component with no mode to exact', () => {
+      renderOptions(
+        search({ component: JSON.stringify({ pattern: 'CCO', target: 'input' }) }),
+      );
+
+      expect(screen.getByText('exact')).toHaveClass('selected');
+    });
+
+    it('reads the stereochemistry and similarity settings', () => {
+      renderOptions(
+        search({
+          component: JSON.stringify({
+            pattern: 'CCO',
+            target: 'input',
+            mode: 'similar',
+          }),
+          use_stereochemistry: 'true',
+          similarity: '0.75',
+        }),
+      );
+
+      expect(screen.getByLabelText('Use Stereochemistry')).toBeChecked();
+      expect(screen.getByLabelText('Similarity Threshold')).toHaveValue('0.75');
+    });
+
+    // The threshold is padded to two decimals for display: 0.5 reads as "0.50".
+    it('pads the similarity threshold for display', () => {
+      renderOptions(
+        search({
+          component: JSON.stringify({
+            pattern: 'CCO',
+            target: 'input',
+            mode: 'similar',
+          }),
+        }),
+      );
+
+      expect(screen.getByText('0.50')).toBeInTheDocument();
+    });
+  });
+
+  describe('reading the other sections from the URL', () => {
+    it('opens the datasets section for dataset ids and DOIs', () => {
+      renderOptions(
+        search({ dataset_id: ['ord_dataset-1', 'ord_dataset-2'], doi: '10.1000/x' }),
+      );
+
+      expect(screen.getByText('ord_dataset-1')).toBeInTheDocument();
+      expect(screen.getByText('ord_dataset-2')).toBeInTheDocument();
+      expect(screen.getByText('10.1000/x')).toBeInTheDocument();
+    });
+
+    it('opens the reactions section for reaction ids and SMARTS', () => {
+      renderOptions(
+        search({ reaction_id: 'ord-abc', reaction_smarts: '[C:1]>>[C:1]O' }),
+      );
+
+      expect(screen.getByText('ord-abc')).toBeInTheDocument();
+      expect(screen.getByText('[C:1]>>[C:1]O')).toBeInTheDocument();
+    });
+
+    it('opens the reactions section for a narrowed yield range', () => {
+      renderOptions(search({ min_yield: '20', max_yield: '80' }));
+
+      expect(sectionIsOpen('Reaction IDs')).toBe(true);
+      expect(screen.getByText('20% - 80%')).toBeInTheDocument();
+    });
+
+    it('opens the reactions section for a narrowed conversion range', () => {
+      renderOptions(search({ min_conversion: '10', max_conversion: '90' }));
+
+      expect(sectionIsOpen('Reaction IDs')).toBe(true);
+      expect(screen.getByText('10% - 90%')).toBeInTheDocument();
+    });
+
+    // Number(undefined) is NaN, and NaN !== 100, so an unguarded comparison
+    // against the default bound opened this section on every page load.
+    it('leaves the reactions section closed with no reaction params', () => {
+      renderOptions(search({ dataset_id: 'ord_dataset-1' }));
+
+      expect(sectionIsOpen('Reaction IDs')).toBe(false);
+    });
+
+    it('leaves the reactions section closed for a full-width range', () => {
+      renderOptions(search({ max_yield: '100', max_conversion: '100' }));
+
+      expect(sectionIsOpen('Reaction IDs')).toBe(false);
+    });
+
+    it('reads the result limit', () => {
+      renderOptions(search({ limit: '25' }));
+      expect(screen.getByLabelText('Result Limit')).toHaveValue(25);
+    });
+  });
+
+  describe('emitting options', () => {
+    it('reports the components with the shared match mode', async () => {
+      const user = userEvent.setup();
+      const { onSearchOptions } = renderOptions(
+        search({
+          component: [
+            JSON.stringify({ pattern: 'CCO', target: 'input', mode: 'exact' }),
+            JSON.stringify({ pattern: 'CC=O', target: 'output', mode: 'exact' }),
+          ],
+          similarity: '0.75',
+          use_stereochemistry: 'true',
+          limit: '25',
+        }),
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Search' }));
+
+      expect(onSearchOptions).toHaveBeenCalledWith({
+        reagent: {
+          reagents: [
+            { smileSmart: 'CCO', source: 'input', matchMode: 'exact' },
+            { smileSmart: 'CC=O', source: 'output', matchMode: 'exact' },
+          ],
+          useStereochemistry: true,
+          similarityThreshold: 0.75,
+        },
+        reaction: {
+          reactionIds: [],
+          reactionSmarts: [],
+          min_yield: 0,
+          max_yield: 100,
+          min_conversion: 0,
+          max_conversion: 100,
+        },
+        dataset: { datasetIds: [], DOIs: [] },
+        general: { limit: 25 },
+      });
+    });
+
+    it('applies a match-mode change to every component', async () => {
+      const user = userEvent.setup();
+      const { onSearchOptions } = renderOptions(
+        search({
+          component: JSON.stringify({
+            pattern: 'CCO',
+            target: 'input',
+            mode: 'exact',
+          }),
+        }),
+      );
+
+      await user.click(screen.getByText('substructure'));
+      await user.click(screen.getByRole('button', { name: 'Search' }));
+
+      expect(onSearchOptions.mock.calls[0][0].reagent.reagents).toEqual([
+        { smileSmart: 'CCO', source: 'input', matchMode: 'substructure' },
+      ]);
+    });
+
+    it('reports components added and edited by hand', async () => {
+      const user = userEvent.setup();
+      const { onSearchOptions } = renderOptions();
+
+      await user.click(screen.getByText('Components'));
+      await user.click(screen.getAllByRole('button', { name: /Add Component/ })[0]);
+      await user.type(smilesInputs()[0], 'CCO');
+      await user.click(screen.getByRole('button', { name: 'Search' }));
+
+      expect(onSearchOptions.mock.calls[0][0].reagent.reagents).toEqual([
+        { smileSmart: 'CCO', source: 'input', matchMode: 'exact' },
+      ]);
+    });
+
+    it('reports a component removed by hand', async () => {
+      const user = userEvent.setup();
+      const { onSearchOptions } = renderOptions(
+        search({
+          component: [
+            JSON.stringify({ pattern: 'CCO', target: 'input', mode: 'exact' }),
+            JSON.stringify({ pattern: 'CCC', target: 'input', mode: 'exact' }),
+          ],
+        }),
+      );
+
+      const [firstDelete] = screen
+        .getAllByRole('button')
+        .filter(button => button.closest('.delete') !== null);
+      await user.click(firstDelete);
+      await user.click(screen.getByRole('button', { name: 'Search' }));
+
+      expect(onSearchOptions.mock.calls[0][0].reagent.reagents).toEqual([
+        { smileSmart: 'CCC', source: 'input', matchMode: 'exact' },
+      ]);
+    });
+
+    it('reports the result limit', async () => {
+      const user = userEvent.setup();
+      const { onSearchOptions } = renderOptions();
+
+      await user.clear(screen.getByLabelText('Result Limit'));
+      await user.type(screen.getByLabelText('Result Limit'), '5');
+      await user.click(screen.getByRole('button', { name: 'Search' }));
+
+      expect(onSearchOptions.mock.calls[0][0].general).toEqual({ limit: 5 });
+    });
+  });
+
+  describe('the structure editor', () => {
+    // ModalKetcher embeds an iframe that never boots under jsdom; these tests
+    // cover the wiring around it, not the editor itself.
+    const drawButtons = () =>
+      screen.getAllByRole('button').filter(button => button.closest('.draw') !== null);
+
+    it('opens the editor on the reactant that was clicked', async () => {
+      const user = userEvent.setup();
+      renderOptions(
+        search({
+          component: [
+            JSON.stringify({ pattern: 'CCO', target: 'input', mode: 'exact' }),
+            JSON.stringify({ pattern: 'CCC', target: 'input', mode: 'exact' }),
+          ],
+        }),
+      );
+
+      await user.click(drawButtons()[1]);
+
+      expect(screen.getByTitle('Ketcher Molecular Editor')).toBeInTheDocument();
+    });
+
+    it('opens the editor on a product', async () => {
+      const user = userEvent.setup();
+      renderOptions(
+        search({
+          component: JSON.stringify({
+            pattern: 'CC=O',
+            target: 'output',
+            mode: 'exact',
+          }),
+        }),
+      );
+
+      await user.click(drawButtons()[0]);
+
+      expect(screen.getByTitle('Ketcher Molecular Editor')).toBeInTheDocument();
+    });
+
+    it('closes the editor without changing anything', async () => {
+      const user = userEvent.setup();
+      renderOptions(
+        search({
+          component: JSON.stringify({
+            pattern: 'CCO',
+            target: 'input',
+            mode: 'exact',
+          }),
+        }),
+      );
+
+      await user.click(drawButtons()[0]);
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.queryByTitle('Ketcher Molecular Editor')).not.toBeInTheDocument();
+      expect(smilesInputs().map(input => input.value)).toEqual(['CCO']);
+    });
+  });
+});

--- a/app/src/views/search/SearchResults.test.tsx
+++ b/app/src/views/search/SearchResults.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SearchResults from './SearchResults';
+import type { ReactionData, SearchResult } from '../../types/search';
+
+const SEARCH = '?dataset_id=ord_dataset-1';
+
+const results = (...ids: string[]): SearchResult[] =>
+  ids.map(id => ({
+    reaction_id: id,
+    dataset_id: 'ord_dataset-1',
+    proto: '',
+    data: {} as ReactionData,
+  }));
+
+let selectedSetSearch = '';
+
+const SelectedSetPage = () => {
+  selectedSetSearch = useLocation().search;
+  return <div>selected set page</div>;
+};
+
+const renderResults = (searchResults: SearchResult[], search = SEARCH) =>
+  render(
+    <MemoryRouter initialEntries={[`/search${search}`]}>
+      <Routes>
+        <Route
+          path="/search"
+          element={<SearchResults searchResults={searchResults} />}
+        />
+        <Route
+          path="/selected-set"
+          element={<SelectedSetPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+const checkboxes = () => screen.getAllByLabelText('Select reaction');
+
+beforeEach(() => {
+  selectedSetSearch = '';
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, status: 200, text: async () => '' })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('SearchResults', () => {
+  it('renders no table without results', () => {
+    renderResults([]);
+    expect(screen.queryByText('Search Results')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Select reaction')).not.toBeInTheDocument();
+  });
+
+  it('renders a card per result', async () => {
+    renderResults(results('ord-1', 'ord-2'));
+    expect(await screen.findAllByLabelText('Select reaction')).toHaveLength(2);
+  });
+
+  it('offers a shareable link and a download', async () => {
+    renderResults(results('ord-1'));
+    expect(await screen.findByText('Shareable Link')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Download All Search Results' }),
+    ).toBeEnabled();
+  });
+
+  it('opens the download modal for every result, not just the selected ones', async () => {
+    const user = userEvent.setup();
+    renderResults(results('ord-1', 'ord-2'));
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Download All Search Results' }),
+    );
+
+    expect(screen.getByText('Download Results')).toBeInTheDocument();
+  });
+
+  describe('selection', () => {
+    it('counts the selected reactions', async () => {
+      const user = userEvent.setup();
+      renderResults(results('ord-1', 'ord-2'));
+
+      await user.click((await screen.findAllByLabelText('Select reaction'))[0]);
+      expect(screen.getByText('View 1 selected reactions')).toBeInTheDocument();
+
+      await user.click(checkboxes()[1]);
+      expect(screen.getByText('View 2 selected reactions')).toBeInTheDocument();
+    });
+
+    it('drops a deselected reaction', async () => {
+      const user = userEvent.setup();
+      renderResults(results('ord-1', 'ord-2'));
+
+      const boxes = await screen.findAllByLabelText('Select reaction');
+      await user.click(boxes[0]);
+      await user.click(boxes[0]);
+
+      expect(screen.queryByText(/selected reactions/)).not.toBeInTheDocument();
+    });
+
+    it('carries the selection to the selected-set page', async () => {
+      const user = userEvent.setup();
+      renderResults(results('ord-1', 'ord-2'));
+
+      await user.click((await screen.findAllByLabelText('Select reaction'))[1]);
+      await user.click(screen.getByText('View 1 selected reactions'));
+
+      expect(screen.getByText('selected set page')).toBeInTheDocument();
+      expect(new URLSearchParams(selectedSetSearch).getAll('reaction_id')).toEqual([
+        'ord-2',
+      ]);
+    });
+
+    // The selection has to survive navigating to the selected-set page and back.
+    it('stores the selection alongside the query that produced it', async () => {
+      const user = userEvent.setup();
+      renderResults(results('ord-1'));
+
+      await user.click((await screen.findAllByLabelText('Select reaction'))[0]);
+      await user.click(screen.getByText('View 1 selected reactions'));
+
+      expect(JSON.parse(localStorage.getItem('storedSet')!)).toEqual({
+        query: SEARCH,
+        reactions: ['ord-1'],
+      });
+    });
+
+    it('restores a stored selection for the same query', async () => {
+      localStorage.setItem(
+        'storedSet',
+        JSON.stringify({ query: SEARCH, reactions: ['ord-2'] }),
+      );
+      renderResults(results('ord-1', 'ord-2'));
+
+      const boxes = await screen.findAllByLabelText('Select reaction');
+      expect(boxes[0]).not.toBeChecked();
+      expect(boxes[1]).toBeChecked();
+    });
+
+    it('ignores a selection stored under a different query', async () => {
+      localStorage.setItem(
+        'storedSet',
+        JSON.stringify({ query: '?dataset_id=other', reactions: ['ord-1'] }),
+      );
+      renderResults(results('ord-1'));
+
+      expect((await screen.findAllByLabelText('Select reaction'))[0]).not.toBeChecked();
+    });
+
+    it('survives a corrupt stored selection', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      localStorage.setItem('storedSet', 'not json');
+      renderResults(results('ord-1'));
+
+      expect(await screen.findAllByLabelText('Select reaction')).toHaveLength(1);
+      expect(consoleError).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
@@ -28,5 +28,9 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts'],
   },
 });


### PR DESCRIPTION
Builds the vitest suite out from the single `LinkedText` test to cover the rest of `app/`: **414 tests across 37 files**, taking statement coverage of `app/src` from ~7% to **95%** (96% of lines). `ord_interface/editor/` is untouched.

## Setup

`jsdom` + Testing Library, so the stateful and interactive code is reachable at all. Three infrastructure changes:

- `vite.config.ts` — `defineConfig` from `vitest/config`, `environment: 'jsdom'`, setup file.
- `src/setupTests.ts` — jest-dom matchers, RTL `cleanup`, and a `localStorage` shim. That last one is not boilerplate: Node exposes an experimental `localStorage` global that evaluates to `undefined` without `--localstorage-file`, and it shadows the one jsdom installs. Without the shim every test touching stored state fails.
- devDeps: `jsdom`, `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom`.

CI already runs `npm test`, so nothing changes in `checks.yml`.

## What's covered

| Area | Highlights |
|---|---|
| `utils/` (100%) | enum reverse-lookup including the zero value, amount/time/percentage/conditions formatting, `fetchJson` error shapes, base64 across the full byte range |
| `hooks/` (97%) | `useSearchTask`'s submit/poll protocol — that it submits exactly once across a poll cycle, the 202 loop, the timeout, both error paths; `useNLQuery` URL building and dry-run cache separation |
| Search | `SearchOptions` URL parsing in both the JSON and legacy `pattern;target;mode` forms (including `;` inside a SMARTS pattern), `MainSearch`'s full URL round-trip, `EntityTable` pagination and AND-across-terms filtering, selection persistence via `localStorage` |
| Reaction view | Every leaf view's label/value grid, plus `MainReactionView` driven by real serialized protos — input ordering by addition order, conditional nav items, tab switching |
| The rest | `MainNLSearch` interpretation panel, `MainDatasetView`, `ChartView` (d3 bars and the hover tooltip), `MainBrowse`, `MainSelectedSet`, `ModalKetcher`, `App` routing |

`ModalKetcher` went from 1.7% to 98% by stubbing `HTMLIFrameElement.prototype.contentWindow` and driving the 1s poll and 30s timeout with fake timers.

The tests deliberately pin the non-obvious decisions — the "don't render an HTML error page through `dangerouslySetInnerHTML`" guard in all four places it appears, and the proto3 zero-default calls (pH, `targetPh`, rpm, precision). Those read as arbitrary until you know why, so they're the ones most likely to get "simplified" away later.

## Bug fix

`EntityTable` left the user on a stale page number when the filter changed: narrow 25 rows down to 3 while on page 3 and you got a blank list with working pagination controls. There was already an effect resetting `currentPage` on a page-size change; `searchString` needed the same treatment. Two tests cover it, and both fail without the one-line fix.

## Verification

`npm test`, `npm run lint`, `npm run format:check`, `tsc -b`, and `npm run build` all pass.

Coverage numbers came from a throwaway `npm install --no-save @vitest/coverage-v8`, pruned afterwards — `package.json` and the lockfile carry only the four testing deps. Happy to add the coverage provider and a `test:coverage` script in a follow-up if that's wanted permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds comprehensive React application tests and supporting test infrastructure.
- Configures Vitest with jsdom, Testing Library setup, cleanup, and an in-memory localStorage shim.
- Adds Testing Library and jsdom development dependencies.
- Expands coverage across components, hooks, utilities, routing, search, dataset, browse, and reaction views.
- Updates EntityTable pagination to reset for filter changes and clamp the current page when replacement data reduces the page count.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failures remain within the follow-up review scope.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/components/EntityTable.tsx | Resets pagination after filter changes and safely clamps stale page numbers when the available page count shrinks. |
| app/src/setupTests.ts | Establishes shared Testing Library cleanup and a deterministic localStorage implementation for jsdom tests. |
| app/vite.config.ts | Configures Vitest to run the expanded suite in jsdom with the shared setup file. |
| app/package.json | Adds Node-compatible Testing Library and jsdom development dependencies for the new test suite. |
| app/package-lock.json | Locks the newly added test dependencies and their transitive packages. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review on the EntityTab..."](https://github.com/open-reaction-database/ord-interface/commit/9565714e7d82cecfbeffadec9bcfe84d18c31061) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47177742)</sub>

<!-- /greptile_comment -->