### PR TITLE
Move off ord-schema's deprecated read_spreadsheet and name_resolve

### DIFF
--- a/ord_interface/editor/py/serve.py
+++ b/ord_interface/editor/py/serve.py
@@ -235,7 +235,7 @@ def enumerate_dataset():
         else:
             spreadsheet_data = data["spreadsheet_data"]
         spreadsheet_data = io.BytesIO(base64.b64decode(spreadsheet_data))
-        dataframe = templating.read_spreadsheet(spreadsheet_data, suffix=suffix)
+        dataframe = templating.load_spreadsheet(spreadsheet_data, suffix=suffix)
         name = f"{basename}_dataset"
         dataset = templating.generate_dataset(
             name=name,
@@ -466,7 +466,7 @@ def resolve_compound(identifier_type):
     if not compound_name:
         return ""
     try:
-        smiles, resolver = resolvers.name_resolve(identifier_type, compound_name)
+        smiles, resolver = resolvers.resolve_name(identifier_type, compound_name)
         return flask.jsonify((_canonicalize_smiles(smiles), resolver))
     except ValueError:
         return ""


### PR DESCRIPTION
`templating.read_spreadsheet` and `resolvers.name_resolve` are forwarding aliases left behind by ord-schema's `load_*`/`save_*` rename, and [ord-schema#909](https://github.com/Open-Reaction-Database/ord-schema/pull/909) removes them. The editor server is the only place in this repository that used either.

Both replacements have identical signatures to the aliases they replace and are already present in the pinned ord-schema 0.8 — `load_spreadsheet(file_name_or_buffer, suffix=None)` and `resolve_name(value_type, value)` — so each call site is a rename and nothing else.

The pin stays at `ord-schema[orm]>=0.8,<0.9`. That bound is what insulates this repository from #909 today; widening it is a separate change once 0.9.0 ships, and this makes the code ready for it.

## Verification

`ruff check`, `ruff format --check`, and `ty check` pass, and I confirmed against the installed 0.8 that both new names resolve with the expected signatures. Both call sites do have test coverage — `test_enumerate_dataset` and `test_resolve_compound` in `serve_test.py` — but those live under `ord_interface/editor`, which the first CI job excludes and the second runs behind PostgreSQL, Redis, and puppeteer; they need the CI services rather than a local run, so I am relying on this PR's own run for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the editor server to use the supported ord-schema API names.
- Replaces `templating.read_spreadsheet` with `templating.load_spreadsheet`.
- Replaces `resolvers.name_resolve` with `resolvers.resolve_name`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The replacement APIs preserve the existing arguments and return contracts and are available throughout the declared ord-schema dependency range.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_interface/editor/py/serve.py | Both deprecated aliases are replaced with equivalent APIs available in the repository’s supported ord-schema version range. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Move off ord-schema&#39;s deprecated read\_sp..."](https://github.com/open-reaction-database/ord-interface/commit/80d72c63b13a156b53726286e6b8a2c9686abf8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47783569)</sub>

<!-- /greptile_comment -->