### PR TITLE
Pin GitHub Actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Actions in .github/workflows are pinned to commit SHAs. Dependabot rewrites
+# both the SHA and its trailing version comment, which is what keeps a pinned
+# workflow from freezing on whatever was current the day it was written.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      # One pull request per month for all actions rather than one per action.
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,8 +24,8 @@ jobs:
   check_licenses:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '>=1.16'
       - name: Install addlicense
@@ -36,8 +36,8 @@ jobs:
   check_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           python-version: "3.12"
@@ -53,8 +53,8 @@ jobs:
   check_javascript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,8 @@ jobs:
     env:
       PGDATA: $GITHUB_WORKSPACE/rdkit-postgres
     steps:
-      - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
         with:
           miniconda-version: 'latest'
       - name: Setup PostgreSQL
@@ -40,12 +40,12 @@ jobs:
           # NOTE(skearnes): conda is only used for postgres (not python).
           conda install -c conda-forge rdkit-postgresql
           initdb
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
       - name: actions-setup-redis
-        uses: shogo82148/actions-setup-redis@v1.35.0
+        uses: shogo82148/actions-setup-redis@428a144f11914412a8f52902296e134dd2e0f925 # v1.35.0
       - name: Install ord_interface
         run: uv sync --frozen
       - name: Run tests
@@ -63,16 +63,16 @@ jobs:
     # NOTE(skearnes): ubuntu-latest AppArmor doesn't play nicely with puppeteer.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       - name: actions-setup-redis
-        uses: shogo82148/actions-setup-redis@v1.35.0
+        uses: shogo82148/actions-setup-redis@428a144f11914412a8f52902296e134dd2e0f925 # v1.35.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Install ord-interface
         run: uv sync --frozen
       - name: Install non-python test dependencies


### PR DESCRIPTION
Version tags are mutable. The `tj-actions/changed-files` compromise in March 2025 repointed every version tag at a commit that dumped runner secrets into build logs, hitting roughly 23,000 repositories; tag pinning offered no protection and SHA pinning offered complete protection. Three of the actions used here are third-party — `astral-sh/setup-uv`, `shogo82148/actions-setup-redis`, and `docker/setup-buildx-action`.

**The Dependabot config is the half that makes this sustainable, and it is not optional.** Dependabot understands SHA-pinned actions and rewrites the SHA together with its trailing `# vN` comment, so pinned workflows keep tracking upstream. Without it, pinning silently freezes the workflows on whatever was current the day they were written — which is exactly what happened in ord-app and ord-infrastructure, both fully SHA-pinned with no update mechanism and both a major version behind on `setup-uv`.

Updates are grouped so this arrives as one pull request a month rather than one per action.

Every pin resolves the tag that was already in use, so nothing changes behavior. Resolved through the git refs API, dereferencing annotated tags to their commits. All pre-commit hooks pass.

Part of an org-wide sweep alongside [ord-schema#910](https://github.com/Open-Reaction-Database/ord-schema/pull/910) and [ord-data#264](https://github.com/open-reaction-database/ord-data/pull/264).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Pins every GitHub Actions dependency to an immutable commit SHA and adds monthly grouped Dependabot updates to keep those pins current.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The workflow changes preserve the existing action versions and valid `uses` syntax, while the new Dependabot configuration covers the pinned actions with a valid grouped monthly update schedule.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds a valid monthly grouped update configuration covering GitHub Actions dependencies throughout the repository. |
| .github/workflows/checks.yml | Replaces mutable action version tags with consistent immutable SHAs while preserving the existing major versions. |
| .github/workflows/tests.yml | Pins all test workflow actions to consistent immutable SHAs without changing job configuration or execution flow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Pin GitHub Actions to commit SHAs and ad..."](https://github.com/open-reaction-database/ord-interface/commit/ecf1fe089e5a34b3bc0d85641c7248db55bd1f2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48150384)</sub>

<!-- /greptile_comment -->